### PR TITLE
Rewrite panel border

### DIFF
--- a/D2Patch.h
+++ b/D2Patch.h
@@ -140,9 +140,15 @@ static const DLLPatchStrc gptTemplatePatches[] =
 
 // Enables border backgrounds for opened panels.
 static const DLLPatchStrc panelBackgroundDrawPatches[] = {
-    // Left panel click block
-    { D2DLL_D2CLIENT, 0x9AE80, PATCH_CALL, FALSE, 0 },
-    { D2DLL_D2CLIENT, 0x9AE80 + 1, (int)HD::DrawUIMercenaryInventoryBackground, TRUE, 0 },
+    /* Assumption is that this patch is already enabled.
+    { D2DLL_D2CLIENT, 0xC39F6, PATCH_NOPBLOCK, FALSE, 39 },
+    { D2DLL_D2CLIENT, 0xC39F6, PATCH_CALL, FALSE, 0 },
+    { D2DLL_D2CLIENT, 0xC39F6 + 1, (int)HD::PanelPosition_Interception, TRUE, 0 },
+    */
+
+    // Draw background
+    { D2DLL_D2CLIENT, 0xC39FB, PATCH_CALL, FALSE, 0 },
+    { D2DLL_D2CLIENT, 0xC39FB + 1, (int)HD::DrawUIPanelBackground, TRUE, 0 },
 
     { D2DLL_INVALID }
 };

--- a/D2Patch.h
+++ b/D2Patch.h
@@ -138,6 +138,15 @@ static const DLLPatchStrc gptTemplatePatches[] =
     { D2DLL_INVALID } // this must be the last entry in the array!
 };
 
+// Enables border backgrounds for opened panels.
+static const DLLPatchStrc panelBackgroundDrawPatches[] = {
+    // Left panel click block
+    { D2DLL_D2CLIENT, 0x9AE80, PATCH_CALL, FALSE, 0 },
+    { D2DLL_D2CLIENT, 0x9AE80 + 1, (int)HD::DrawUIMercenaryInventoryBackground, TRUE, 0 },
+
+    { D2DLL_INVALID }
+};
+
 // Fixes border panel click detection issue for HD mode. Shouldn't need to be disabled.
 static const DLLPatchStrc borderPanelClickDetectionPatches[] = {
     // Left panel click block

--- a/D2Patch.h
+++ b/D2Patch.h
@@ -45,12 +45,12 @@ static const DLLPatchStrc gptTemplatePatches[] =
     { D2DLL_D2CLIENT, 0x29262 + 1, (int)HD::GetResolutionMode_Interception, TRUE, 0 },
 
     // Redraw UI Panel Border Fix
-    { D2DLL_D2CLIENT, 0x271ED, PATCH_NOPBLOCK, FALSE, 154 },
-    { D2DLL_D2CLIENT, 0x271ED, PATCH_CALL, FALSE, 0 },
-    { D2DLL_D2CLIENT, 0x271ED + 1, (int)HD::RedrawUILeftPanelBorders_Interception, TRUE, 0 },
-    { D2DLL_D2CLIENT, 0x270F2, PATCH_NOPBLOCK, FALSE, 187 },
-    { D2DLL_D2CLIENT, 0x270F2, PATCH_CALL, FALSE, 0 },
-    { D2DLL_D2CLIENT, 0x270F2 + 1, (int)HD::RedrawUIRightPanelBorders_Interception, TRUE, 0 },
+    { D2DLL_D2CLIENT, 0x271C0, PATCH_NOPBLOCK, FALSE, 203 },
+    { D2DLL_D2CLIENT, 0x271C0, PATCH_CALL, FALSE, 0 },
+    { D2DLL_D2CLIENT, 0x271C0 + 1, (int)HD::RedrawUILeftPanelBorders_Interception, TRUE, 0 },
+    { D2DLL_D2CLIENT, 0x270D0, PATCH_NOPBLOCK, FALSE, 225 },
+    { D2DLL_D2CLIENT, 0x270D0, PATCH_CALL, FALSE, 0 },
+    { D2DLL_D2CLIENT, 0x270D0 + 1, (int)HD::RedrawUIRightPanelBorders_Interception, TRUE, 0 },
 
     // Replace for HD, Resize Game Window
     { D2DLL_D2GFX, 0x7FE8 + 2, RESOLUTION_640_TO_HD_WIDTH, FALSE, 0 },

--- a/D2Ptrs.h
+++ b/D2Ptrs.h
@@ -58,6 +58,9 @@ D2VAR(D2CLIENT, ScreenSizeY, DWORD, 0xDBC4C);
 D2VAR(D2CLIENT, PanelOffsetX, int, 0x11B9A0);
 D2VAR(D2CLIENT, PanelOffsetY, int, 0x11B9A4);
 D2VAR(D2CLIENT, InventoryArrangeMode, int, 0x11B99C);
+D2VAR(D2CLIENT, PanelBorderImage, void*, 0x11A77C);
+
+D2FUNC(D2CLIENT, LoadUIImage, void*, __fastcall, (const char* szImage), 0xBF6C0);
 
 /********************************************************************************
 *                                                                               *
@@ -85,7 +88,7 @@ D2VAR(D2GDI, ForegroundRenderWidth, int, 0xCA9C);
 *                                                                               *
 *********************************************************************************/
 D2FUNC(D2GFX, GetResolutionMode, int, __stdcall, (), 0xB320);
-D2FUNC(D2GFX, D2DrawImage, void, __stdcall, (int* pFrameNumber, int nXpos, int nYpos, DWORD color, int nTransTbl, unsigned char* pPalette), 0xB080);
+D2FUNC(D2GFX, D2DrawImage, void, __stdcall, (D2ImageDrawStrc* pFrameNumber, int nXpos, int nYpos, DWORD color, int nTransTbl, unsigned char* pPalette), 0xB080);
 
 /********************************************************************************
 *                                                                               *

--- a/D2Ptrs.h
+++ b/D2Ptrs.h
@@ -59,7 +59,7 @@ D2VAR(D2CLIENT, PanelOffsetX, int, 0x11B9A0);
 D2VAR(D2CLIENT, PanelOffsetY, int, 0x11B9A4);
 D2VAR(D2CLIENT, InventoryArrangeMode, int, 0x11B99C);
 D2VAR(D2CLIENT, PanelBorderImage, void*, 0x11A77C);
-D2VAR(D2CLIENT, Something, DWORD, 0x119854);
+D2VAR(D2CLIENT, PanelOpenMode, int, 0x11C414);
 
 D2FUNC(D2CLIENT, LoadUIImage, void*, __fastcall, (const char* szImage), 0xBF6C0);
 

--- a/D2Ptrs.h
+++ b/D2Ptrs.h
@@ -59,8 +59,18 @@ D2VAR(D2CLIENT, PanelOffsetX, int, 0x11B9A0);
 D2VAR(D2CLIENT, PanelOffsetY, int, 0x11B9A4);
 D2VAR(D2CLIENT, InventoryArrangeMode, int, 0x11B99C);
 D2VAR(D2CLIENT, PanelBorderImage, void*, 0x11A77C);
+D2VAR(D2CLIENT, Something, DWORD, 0x119854);
 
 D2FUNC(D2CLIENT, LoadUIImage, void*, __fastcall, (const char* szImage), 0xBF6C0);
+
+// Only use as a reference! Called inside of D2client.dll+C39E0
+D2FUNC(D2CLIENT, DrawMercenaryInventoryPanel, void*, __fastcall, (), 0x9AE80);
+D2FUNC(D2CLIENT, DrawInfusScrollPanel, void*, __fastcall, (), 0x7DE00);
+D2FUNC(D2CLIENT, DrawInventoryPanel, void*, __fastcall, (), 0x99440);
+D2FUNC(D2CLIENT, DrawQuestPanel, void*, __fastcall, (), 0x1EF10);
+D2FUNC(D2CLIENT, DrawSkillPanel, void*, __fastcall, (), 0x78F20);
+D2FUNC(D2CLIENT, DrawStatPanel, void*, __fastcall, (), 0xBCEA0);
+
 
 /********************************************************************************
 *                                                                               *
@@ -88,7 +98,7 @@ D2VAR(D2GDI, ForegroundRenderWidth, int, 0xCA9C);
 *                                                                               *
 *********************************************************************************/
 D2FUNC(D2GFX, GetResolutionMode, int, __stdcall, (), 0xB320);
-D2FUNC(D2GFX, D2DrawImage, void, __stdcall, (D2ImageDrawStrc* pFrameNumber, int nXpos, int nYpos, DWORD color, int nTransTbl, unsigned char* pPalette), 0xB080);
+D2FUNC(D2GFX, DrawImage, void, __stdcall, (D2ImageDrawStrc* pFrameNumber, int nXpos, int nYpos, DWORD color, int nTransTbl, unsigned char* pPalette), 0xB080);
 
 /********************************************************************************
 *                                                                               *
@@ -97,6 +107,13 @@ D2FUNC(D2GFX, D2DrawImage, void, __stdcall, (D2ImageDrawStrc* pFrameNumber, int 
 *********************************************************************************/
 D2VAR(D2GLIDE, ScreenSizeX, DWORD, 0x15A68);
 D2VAR(D2GLIDE, ScreenSizeY, DWORD, 0x15B04);
+
+/********************************************************************************
+*                                                                               *
+*   D2WIN.DLL POINTERS                                                          *
+*                                                                               *
+*********************************************************************************/
+D2FUNC(D2WIN, LoadArchive, void*, __stdcall, (const char* pDllName, const char* pMPQName, const char* pMPQTitle, DWORD dwZero, DWORD dwZero2, DWORD dwZero3, DWORD dwOverideFlag), 0x0);
 
 /********************************************************************************
 *                                                                               *

--- a/D2Structs.h
+++ b/D2Structs.h
@@ -60,10 +60,12 @@ struct D2UnitStrc
 
 struct D2ImageDrawStrc      //sizeof 0x48
 {
-    unsigned long dw1[15];   //+00
-    const void* pCellFile;   //+3C
-    int nFrame;            //+40
-    unsigned long dw2;      //+44
+    int nFrame; // 0x00
+    int dw1[12];    // 0x04
+    const void* pCellFile;  // 0x34
+    int dw2[2]; // 0x38
+    int dw3;    // 0x40
+    int dw4;    // 0x44
 };
 
 // end of file --------------------------------------------------------------

--- a/D2Vars.h
+++ b/D2Vars.h
@@ -44,5 +44,9 @@ VAR(DWORD, RightPanelBackgroundColor)
 
 VAR(BOOL, EnableCinematicsFix)
 
+VAR(void*, D2MRArchive)
+
+VAR(void*, D2MRStoneBackground)
+
 // end of file ---------------------------------------------------------------
 #undef _D2VARS_H

--- a/DLLmain.cpp
+++ b/DLLmain.cpp
@@ -154,6 +154,7 @@ int __stdcall DllAttach()
 
     D2TEMPLATE_ApplyPatch(hGame, gptTemplatePatches);
     D2TEMPLATE_ApplyPatch(hGame, borderPanelClickDetectionPatches);
+    D2TEMPLATE_ApplyPatch(hGame, panelBackgroundDrawPatches);
 
     return 1;
 }

--- a/HD/D2HDPatches.cpp
+++ b/HD/D2HDPatches.cpp
@@ -198,9 +198,24 @@ void HD::RedrawUIRightPanelBorders_Interception() {
     __asm pop edi
 }
 
-int HD::DrawUIMercenaryInventoryBackground() {
-    DrawUILeftPanelBackground();
-    return *D2CLIENT_Something;
+void HD::DrawUIPanelBackground() {
+    switch (*D2CLIENT_PanelOpenMode) {
+    case 1:
+        DrawUIRightPanelBackground();
+        break;
+
+    case 2:
+        DrawUILeftPanelBackground();
+        break;
+
+    case 3:
+        DrawUILeftPanelBackground();
+        DrawUIRightPanelBackground();
+        break;
+
+    default:
+        break;
+    }
 }
 
 // Draws a background on opened left panels to cover up extra space.
@@ -222,9 +237,9 @@ void DrawUILeftPanelBackground() {
     for (int row = 0; (row * backHeight) < *D2CLIENT_ScreenSizeY; row++) {
         DWORD backBasePositionY = ((row + 1) * backHeight);
 
-        for (int col = 0; (int)((basePositionX + 80) - (col * backWidth)) >= 0; col++) {
+        for (int col = 0; (int)(basePositionX - (col * backWidth)) >= 0; col++) {
             image.nFrame = ((row % 2) * 2) + (col % 2);
-            DWORD backBasePositionX = (basePositionX + 80) - ((col + 1) * backWidth);
+            DWORD backBasePositionX = basePositionX - ((col + 1) * backWidth);
 
             D2GFX_DrawImage(&image, backBasePositionX, backBasePositionY, LeftPanelBackgroundColor, 5, 0);
         }
@@ -250,7 +265,7 @@ void DrawUIRightPanelBackground() {
     for (int row = 0; (row * backHeight) < *D2CLIENT_ScreenSizeY; row++) {
         DWORD backBasePositionY = ((row + 1) * backHeight);
         for (int col = 0; basePositionX + (col * backWidth) < *D2CLIENT_ScreenSizeX; col++) {
-            image.nFrame = ((row % 2) * 2) + (col % 2);
+            image.nFrame = ((row % 2) * 2) + ((col + 1) % 2);
             DWORD backBasePositionX = basePositionX + (col * backWidth);
 
             D2GFX_DrawImage(&image, backBasePositionX, backBasePositionY, RightPanelBackgroundColor, 5, 0);

--- a/HD/D2HDPatches.cpp
+++ b/HD/D2HDPatches.cpp
@@ -103,16 +103,33 @@ void HD::PanelPosition_Interception() {
     *D2CLIENT_PanelOffsetY = ((int)*D2CLIENT_ScreenSizeY - 480) / -2;
 }
 
+__declspec(naked) void* __stdcall LoadCellFile(const char* szBuffer)
+{
+    __asm
+    {
+        PUSH ESI
+            MOV ESI, [ESP + 8]
+            CALL[D2CLIENT_LoadUIImage]
+            POP ESI
+            RETN 4
+    }
+}
+
 // Redraws the left side panel borders in the correct places, independent of resolution.
 // In addition, also draws a background to cover up extra space.
 void HD::RedrawUILeftPanelBorders_Interception() {
-    __asm {
-        mov dword ptr ds : [ebp + 0x30], eax
+    __asm push edi
+
+    if (*D2CLIENT_PanelBorderImage == NULL) {
+        *D2CLIENT_PanelBorderImage = LoadCellFile("Panel\\800BorderFrame");
     }
+
+    D2ImageDrawStrc image = { 0 };
+    image.pCellFile = *D2CLIENT_PanelBorderImage;
+    image.nFrame = 10;
 
     int basePositionX = (*D2CLIENT_ScreenSizeX / 2) - 400;
     int basePositionY = (*D2CLIENT_ScreenSizeY / 2) - 300;
-    int frameNumber = 10;
 
     // Draw background pieces
     const DWORD backWidth = 256;
@@ -122,51 +139,53 @@ void HD::RedrawUILeftPanelBorders_Interception() {
         DWORD backBasePositionY = ((row + 1) * backHeight);
 
         for (int col = 0; (int)((basePositionX + 80) - (col * backWidth)) >= 0; col++) {
-            frameNumber = 10 + ((row % 2) * 2) + (col % 2);
+            image.nFrame = 10 + ((row % 2) * 2) + (col % 2);
             DWORD backBasePositionX = (basePositionX + 80) - ((col + 1) * backWidth);
 
-            D2GFX_D2DrawImage(&frameNumber, backBasePositionX, backBasePositionY, LeftPanelBackgroundColor, 5, 0);
+            D2GFX_D2DrawImage(&image, backBasePositionX, backBasePositionY, LeftPanelBackgroundColor, 5, 0);
         }
     }
 
-    frameNumber = 0;
+    image.nFrame = 0;
 
     // Frame 0
-    D2GFX_D2DrawImage(&frameNumber, basePositionX, basePositionY + 253, LeftPanelBorderColor, 5, 0);
-    frameNumber++;
+    D2GFX_D2DrawImage(&image, basePositionX, basePositionY + 253, LeftPanelBorderColor, 5, 0);
+    image.nFrame++;
 
     // Frame 1
-    D2GFX_D2DrawImage(&frameNumber, basePositionX + 256, basePositionY + 63, LeftPanelBorderColor, 5, 0);
-    frameNumber++;
+    D2GFX_D2DrawImage(&image, basePositionX + 256, basePositionY + 63, LeftPanelBorderColor, 5, 0);
+    image.nFrame++;
 
     // Frame 2
-    D2GFX_D2DrawImage(&frameNumber, basePositionX, basePositionY + 484, LeftPanelBorderColor, 5, 0);
-    frameNumber++;
+    D2GFX_D2DrawImage(&image, basePositionX, basePositionY + 484, LeftPanelBorderColor, 5, 0);
+    image.nFrame++;
 
     // Frame 3
-    D2GFX_D2DrawImage(&frameNumber, basePositionX, basePositionY + 553, LeftPanelBorderColor, 5, 0);
-    frameNumber++;
+    D2GFX_D2DrawImage(&image, basePositionX, basePositionY + 553, LeftPanelBorderColor, 5, 0);
+    image.nFrame++;
 
     // Frame 4
-    D2GFX_D2DrawImage(&frameNumber, basePositionX + 256, basePositionY + 553, LeftPanelBorderColor, 5, 0);
-    frameNumber++;
+    D2GFX_D2DrawImage(&image, basePositionX + 256, basePositionY + 553, LeftPanelBorderColor, 5, 0);
+    image.nFrame++;
+
+    __asm pop edi
 }
 
 // Redraws the right side panel borders in the correct places, independent of resolution.
 // In addition, also draws a background to cover up extra space.
 void HD::RedrawUIRightPanelBorders_Interception() {
-    __asm {
-        xor eax, eax
-            mov ecx, 18
-            lea edi, [ebp + 0x0C]
-            repe stosd
-            mov dword ptr ds : [ebp + 0x30], edx
+    __asm push edi
+
+    if (*D2CLIENT_PanelBorderImage == NULL) {
+        *D2CLIENT_PanelBorderImage = LoadCellFile("Panel/800BorderFrame");
     }
+
+    D2ImageDrawStrc image = { 0 };
+    image.pCellFile = *D2CLIENT_PanelBorderImage;
+    image.nFrame = 10;
 
     int basePositionX = (*D2CLIENT_ScreenSizeX / 2);
     int basePositionY = (*D2CLIENT_ScreenSizeY / 2) - 300;
-    int frameNumber = 10;
-
 
     // Draw background pieces
     const DWORD backWidth = 256;
@@ -175,34 +194,36 @@ void HD::RedrawUIRightPanelBorders_Interception() {
     for (int row = 0; (row * backHeight) < *D2CLIENT_ScreenSizeY; row++) {
         DWORD backBasePositionY = ((row + 1) * backHeight);
         for (int col = 0; (basePositionX + 320) + (col * backWidth) < *D2CLIENT_ScreenSizeX; col++) {
-            frameNumber = 10 + ((row % 2) * 2) + (col % 2);
+            image.nFrame = 10 + ((row % 2) * 2) + (col % 2);
             DWORD backBasePositionX = (basePositionX + 320) + (col * backWidth);
 
-            D2GFX_D2DrawImage(&frameNumber, backBasePositionX, backBasePositionY, RightPanelBackgroundColor, 5, 0);
+            D2GFX_D2DrawImage(&image, backBasePositionX, backBasePositionY, RightPanelBackgroundColor, 5, 0);
         }
     }
 
-    frameNumber = 5;
+    image.nFrame = 5;
 
     // Frame 5
-    D2GFX_D2DrawImage(&frameNumber, basePositionX, basePositionY + 63, RightPanelBorderColor, 5, 0);
-    frameNumber++;
+    D2GFX_D2DrawImage(&image, basePositionX, basePositionY + 63, RightPanelBorderColor, 5, 0);
+    image.nFrame++;
 
     // Frame 6
-    D2GFX_D2DrawImage(&frameNumber, basePositionX + 144, basePositionY + 253, RightPanelBorderColor, 5, 0);
-    frameNumber++;
+    D2GFX_D2DrawImage(&image, basePositionX + 144, basePositionY + 253, RightPanelBorderColor, 5, 0);
+    image.nFrame++;
 
     // Frame 7
-    D2GFX_D2DrawImage(&frameNumber, basePositionX + 313, basePositionY + 484, RightPanelBorderColor, 5, 0);
-    frameNumber++;
+    D2GFX_D2DrawImage(&image, basePositionX + 313, basePositionY + 484, RightPanelBorderColor, 5, 0);
+    image.nFrame++;
 
     // Frame 8
-    D2GFX_D2DrawImage(&frameNumber, basePositionX + 144, basePositionY + 553, RightPanelBorderColor, 5, 0);
-    frameNumber++;
+    D2GFX_D2DrawImage(&image, basePositionX + 144, basePositionY + 553, RightPanelBorderColor, 5, 0);
+    image.nFrame++;
 
     // Frame 9
-    D2GFX_D2DrawImage(&frameNumber, basePositionX, basePositionY + 553, RightPanelBorderColor, 5, 0);
-    frameNumber++;
+    D2GFX_D2DrawImage(&image, basePositionX, basePositionY + 553, RightPanelBorderColor, 5, 0);
+    image.nFrame++;
+
+    __asm pop edi
 }
 
 // This function is used to prevent running unwanted 640 code.

--- a/HD/D2HDPatches.cpp
+++ b/HD/D2HDPatches.cpp
@@ -2,6 +2,9 @@
 #include "../DLLmain.h"
 #include "../D2Ptrs.h"
 
+void DrawUILeftPanelBackground();
+void DrawUIRightPanelBackground();
+
 void HD::Replace640_ResizeWindow_Interception() {
     __asm {
         mov dword ptr ds : [eax], RESOLUTION_640_TO_HD_WIDTH; Requires registers due to the
@@ -116,12 +119,11 @@ __declspec(naked) void* __stdcall LoadCellFile(const char* szBuffer)
 }
 
 // Redraws the left side panel borders in the correct places, independent of resolution.
-// In addition, also draws a background to cover up extra space.
 void HD::RedrawUILeftPanelBorders_Interception() {
     __asm push edi
 
     if (*D2CLIENT_PanelBorderImage == NULL) {
-        *D2CLIENT_PanelBorderImage = LoadCellFile("Panel\\800BorderFrame");
+        *D2CLIENT_PanelBorderImage = LoadCellFile("Panel/800BorderFrame");
     }
 
     D2ImageDrawStrc image = { 0 };
@@ -131,48 +133,32 @@ void HD::RedrawUILeftPanelBorders_Interception() {
     int basePositionX = (*D2CLIENT_ScreenSizeX / 2) - 400;
     int basePositionY = (*D2CLIENT_ScreenSizeY / 2) - 300;
 
-    // Draw background pieces
-    const DWORD backWidth = 256;
-    const DWORD backHeight = 256;
-
-    for (int row = 0; (row * backHeight) < *D2CLIENT_ScreenSizeY; row++) {
-        DWORD backBasePositionY = ((row + 1) * backHeight);
-
-        for (int col = 0; (int)((basePositionX + 80) - (col * backWidth)) >= 0; col++) {
-            image.nFrame = 10 + ((row % 2) * 2) + (col % 2);
-            DWORD backBasePositionX = (basePositionX + 80) - ((col + 1) * backWidth);
-
-            D2GFX_D2DrawImage(&image, backBasePositionX, backBasePositionY, LeftPanelBackgroundColor, 5, 0);
-        }
-    }
-
     image.nFrame = 0;
 
     // Frame 0
-    D2GFX_D2DrawImage(&image, basePositionX, basePositionY + 253, LeftPanelBorderColor, 5, 0);
+    D2GFX_DrawImage(&image, basePositionX, basePositionY + 253, LeftPanelBorderColor, 5, 0);
     image.nFrame++;
 
     // Frame 1
-    D2GFX_D2DrawImage(&image, basePositionX + 256, basePositionY + 63, LeftPanelBorderColor, 5, 0);
+    D2GFX_DrawImage(&image, basePositionX + 256, basePositionY + 63, LeftPanelBorderColor, 5, 0);
     image.nFrame++;
 
     // Frame 2
-    D2GFX_D2DrawImage(&image, basePositionX, basePositionY + 484, LeftPanelBorderColor, 5, 0);
+    D2GFX_DrawImage(&image, basePositionX, basePositionY + 484, LeftPanelBorderColor, 5, 0);
     image.nFrame++;
 
     // Frame 3
-    D2GFX_D2DrawImage(&image, basePositionX, basePositionY + 553, LeftPanelBorderColor, 5, 0);
+    D2GFX_DrawImage(&image, basePositionX, basePositionY + 553, LeftPanelBorderColor, 5, 0);
     image.nFrame++;
 
     // Frame 4
-    D2GFX_D2DrawImage(&image, basePositionX + 256, basePositionY + 553, LeftPanelBorderColor, 5, 0);
+    D2GFX_DrawImage(&image, basePositionX + 256, basePositionY + 553, LeftPanelBorderColor, 5, 0);
     image.nFrame++;
 
     __asm pop edi
 }
 
 // Redraws the right side panel borders in the correct places, independent of resolution.
-// In addition, also draws a background to cover up extra space.
 void HD::RedrawUIRightPanelBorders_Interception() {
     __asm push edi
 
@@ -187,43 +173,89 @@ void HD::RedrawUIRightPanelBorders_Interception() {
     int basePositionX = (*D2CLIENT_ScreenSizeX / 2);
     int basePositionY = (*D2CLIENT_ScreenSizeY / 2) - 300;
 
+    image.nFrame = 5;
+
+    // Frame 5
+    D2GFX_DrawImage(&image, basePositionX, basePositionY + 63, RightPanelBorderColor, 5, 0);
+    image.nFrame++;
+
+    // Frame 6
+    D2GFX_DrawImage(&image, basePositionX + 144, basePositionY + 253, RightPanelBorderColor, 5, 0);
+    image.nFrame++;
+
+    // Frame 7
+    D2GFX_DrawImage(&image, basePositionX + 313, basePositionY + 484, RightPanelBorderColor, 5, 0);
+    image.nFrame++;
+
+    // Frame 8
+    D2GFX_DrawImage(&image, basePositionX + 144, basePositionY + 553, RightPanelBorderColor, 5, 0);
+    image.nFrame++;
+
+    // Frame 9
+    D2GFX_DrawImage(&image, basePositionX, basePositionY + 553, RightPanelBorderColor, 5, 0);
+    image.nFrame++;
+
+    __asm pop edi
+}
+
+int HD::DrawUIMercenaryInventoryBackground() {
+    DrawUILeftPanelBackground();
+    return *D2CLIENT_Something;
+}
+
+// Draws a background on opened left panels to cover up extra space.
+void DrawUILeftPanelBackground() {
+    if (D2MRStoneBackground == NULL) {
+        D2MRStoneBackground = LoadCellFile(/*"data/global/ui/*/"Panel/D2MRStoneBack");
+    }
+
+    D2ImageDrawStrc image = { 0 };
+    image.pCellFile = D2MRStoneBackground;
+    image.nFrame = 0;
+
+    int basePositionX = (*D2CLIENT_ScreenSizeX / 2);
+
     // Draw background pieces
     const DWORD backWidth = 256;
     const DWORD backHeight = 256;
 
     for (int row = 0; (row * backHeight) < *D2CLIENT_ScreenSizeY; row++) {
         DWORD backBasePositionY = ((row + 1) * backHeight);
-        for (int col = 0; (basePositionX + 320) + (col * backWidth) < *D2CLIENT_ScreenSizeX; col++) {
-            image.nFrame = 10 + ((row % 2) * 2) + (col % 2);
-            DWORD backBasePositionX = (basePositionX + 320) + (col * backWidth);
 
-            D2GFX_D2DrawImage(&image, backBasePositionX, backBasePositionY, RightPanelBackgroundColor, 5, 0);
+        for (int col = 0; (int)((basePositionX + 80) - (col * backWidth)) >= 0; col++) {
+            image.nFrame = ((row % 2) * 2) + (col % 2);
+            DWORD backBasePositionX = (basePositionX + 80) - ((col + 1) * backWidth);
+
+            D2GFX_DrawImage(&image, backBasePositionX, backBasePositionY, LeftPanelBackgroundColor, 5, 0);
         }
     }
+}
 
-    image.nFrame = 5;
+// Draws a background on opened right panels to cover up extra space.
+void DrawUIRightPanelBackground() {
+    if (D2MRStoneBackground == NULL) {
+        D2MRStoneBackground = LoadCellFile("Panel/D2MRStoneBack");
+    }
 
-    // Frame 5
-    D2GFX_D2DrawImage(&image, basePositionX, basePositionY + 63, RightPanelBorderColor, 5, 0);
-    image.nFrame++;
+    D2ImageDrawStrc image = { 0 };
+    image.pCellFile = D2MRStoneBackground;
+    image.nFrame = 0;
 
-    // Frame 6
-    D2GFX_D2DrawImage(&image, basePositionX + 144, basePositionY + 253, RightPanelBorderColor, 5, 0);
-    image.nFrame++;
+    int basePositionX = (*D2CLIENT_ScreenSizeX / 2);
 
-    // Frame 7
-    D2GFX_D2DrawImage(&image, basePositionX + 313, basePositionY + 484, RightPanelBorderColor, 5, 0);
-    image.nFrame++;
+    // Draw background pieces
+    const DWORD backWidth = 256;
+    const DWORD backHeight = 256;
 
-    // Frame 8
-    D2GFX_D2DrawImage(&image, basePositionX + 144, basePositionY + 553, RightPanelBorderColor, 5, 0);
-    image.nFrame++;
+    for (int row = 0; (row * backHeight) < *D2CLIENT_ScreenSizeY; row++) {
+        DWORD backBasePositionY = ((row + 1) * backHeight);
+        for (int col = 0; basePositionX + (col * backWidth) < *D2CLIENT_ScreenSizeX; col++) {
+            image.nFrame = ((row % 2) * 2) + (col % 2);
+            DWORD backBasePositionX = basePositionX + (col * backWidth);
 
-    // Frame 9
-    D2GFX_D2DrawImage(&image, basePositionX, basePositionY + 553, RightPanelBorderColor, 5, 0);
-    image.nFrame++;
-
-    __asm pop edi
+            D2GFX_DrawImage(&image, backBasePositionX, backBasePositionY, RightPanelBackgroundColor, 5, 0);
+        }
+    }
 }
 
 // This function is used to prevent running unwanted 640 code.

--- a/HD/D2HDPatches.h
+++ b/HD/D2HDPatches.h
@@ -32,8 +32,7 @@ namespace HD {
     void PanelPosition_Interception();
     void RedrawUILeftPanelBorders_Interception();
     void RedrawUIRightPanelBorders_Interception();
-    
-    int DrawUIMercenaryInventoryBackground();
+    void DrawUIPanelBackground();
 
     int __fastcall GetResolutionMode_Interception();
 }

--- a/HD/D2HDPatches.h
+++ b/HD/D2HDPatches.h
@@ -32,6 +32,9 @@ namespace HD {
     void PanelPosition_Interception();
     void RedrawUILeftPanelBorders_Interception();
     void RedrawUIRightPanelBorders_Interception();
+    
+    int DrawUIMercenaryInventoryBackground();
+
     int __fastcall GetResolutionMode_Interception();
 }
 


### PR DESCRIPTION
Rewrite panel border code to do the following:
* Utilize proper D2 function calls instead of relying on hacks.
* Properly position background elements for resolutions where the height is larger than 600.
* Utilize external dc6 files instead of modifying old files.
