### PR TITLE
Fix memory leak

### DIFF
--- a/D2Patch.h
+++ b/D2Patch.h
@@ -45,13 +45,9 @@ static const DLLPatchStrc gptTemplatePatches[] =
     { D2DLL_D2CLIENT, 0x29262 + 1, (int)HD::GetResolutionMode_Patch, TRUE, 0 },
 
     // Resize Game Window; D2GFX.Ordinal10025
-    { D2DLL_D2GFX, 0x7FD4, 0x81, FALSE, 1 },
-    { D2DLL_D2GFX, 0x7FD4 + 2, NUMBER_OF_CUSTOM_RESOLUTIONS, FALSE, 0 },
-    { D2DLL_D2GFX, 0x7FDA, 0x4977, FALSE, 0 },
-    { D2DLL_D2GFX, 0x7FDC, PATCH_NOPBLOCK, FALSE, 73 },
-    { D2DLL_D2GFX, 0x7FDC, PATCH_CALL, FALSE, 0 },
-    { D2DLL_D2GFX, 0x7FDC + 1, (int)HD::ResizeWindow_Interception, TRUE, 0 },
-    { D2DLL_D2GFX, 0x7FE1, PATCH_RETN0C | 0x90000000, FALSE, 0 },
+    { D2DLL_D2GFX, 0x7FD0, PATCH_NOPBLOCK, FALSE, 0x8022 - 0x7FD0 },
+    { D2DLL_D2GFX, 0x7FD0, PATCH_JMP, FALSE, 0 },
+    { D2DLL_D2GFX, 0x7FD0 + 1, (int)HD::D2GFX_GetModeParams, TRUE, 0 },
 
     // Resize Rendering Resolution
     { D2DLL_D2GDI, 0x6D34, PATCH_NOPBLOCK, FALSE, 43 },

--- a/D2Patch.h
+++ b/D2Patch.h
@@ -112,10 +112,18 @@ static const DLLPatchStrc gptTemplatePatches[] =
     { D2DLL_D2CLIENT, 0x66279, PATCH_CALL, FALSE, 0 },
     { D2DLL_D2CLIENT, 0x66279 + 1, (int)HD::LoadRegistryResolution_Interception, TRUE, 0 },
 
+    { D2DLL_D2CLIENT, 0x44454, PATCH_NOPBLOCK, FALSE, 0x44464 - 0x44454 },
+    { D2DLL_D2CLIENT, 0x44454, PATCH_CALL, FALSE, 0 },
+    { D2DLL_D2CLIENT, 0x44454 + 1, (int)HD::LoadRegistryResolution_Interception, TRUE, 0 },
+
     // Properly transfer back to a valid resolution
     { D2DLL_D2CLIENT, 0x6628F, PATCH_NOPBLOCK, FALSE, 7 },
     { D2DLL_D2CLIENT, 0x6628F, PATCH_CALL, FALSE, 0 },
     { D2DLL_D2CLIENT, 0x6628F + 1, (int)HD::SetResolutionModeOnGameStart_Interception, TRUE, 0 },
+
+    { D2DLL_D2CLIENT, 0x4446B, PATCH_NOPBLOCK, FALSE, 7 },
+    { D2DLL_D2CLIENT, 0x4446B, PATCH_CALL, FALSE, 0 },
+    { D2DLL_D2CLIENT, 0x4446B + 1, (int)HD::SetResolutionModeOnGameStart_Interception, TRUE, 0 },
 
     // Write to D2HD.ini Instead of Registry
     { D2DLL_D2CLIENT, 0x662AB, PATCH_NOPBLOCK, FALSE, 0x662BC - 0x662AB },

--- a/D2Ptrs.h
+++ b/D2Ptrs.h
@@ -108,7 +108,8 @@ D2VAR(D2GDI, ForegroundRenderWidth, DWORD, 0xCA9C);
 *   D2GFX.DLL POINTERS                                                          *
 *                                                                               *
 *********************************************************************************/
-D2VAR(D2GFX, GfxMode, int, 0x11258)
+D2VAR(D2GFX, GfxMode, int, 0x11258);
+D2VAR(D2GFX, ResolutionMode, int, 0x11260);
 
 D2FUNC(D2GFX, GetResolutionMode, int, __stdcall, (), 0xB320);
 D2FUNC(D2GFX, DrawImage, void, __stdcall, (CellContext* pCellContext, int nXpos, int nYpos, DWORD color, int nTransTbl, unsigned char* pPalette), 0xB080);


### PR DESCRIPTION
* Fix memory leak caused by transferring from a resolution that has a different value than that which is stored in the Registry.