### PR TITLE
Fix classic bank inventory y-position alignment.

### DIFF
--- a/HD/D2HDInventory.cpp
+++ b/HD/D2HDInventory.cpp
@@ -116,7 +116,7 @@ void __stdcall Inventory::GetInventoryGrid(int nRecord, int nScreenMode, Invento
         }
 
         int xInvBottomOffset = pTxt->Inventory.dwTop - pTxt->Grid.dwTop;
-        if (nRecord == INV_REC_CUBE || nRecord == INV_REC_BIG_BANK) {
+        if (nRecord == INV_REC_CUBE || nRecord == INV_REC_BIG_BANK || nRecord == INV_REC_BANK) {
             xInvBottomOffset -= 112;
         }
 


### PR DESCRIPTION
Align the classic bank in the correct y-position.