### PR TITLE
Fix resolution lag

### DIFF
--- a/D2Patch.h
+++ b/D2Patch.h
@@ -89,13 +89,13 @@ static const DLLPatchStrc gptTemplatePatches[] =
     { D2DLL_D2CLIENT, { 0x44454 + 1, 0x454A4 + 1 }, (int)HD::LoadRegistryResolution_Interception, TRUE, 0 },
 
     // Properly transfer back to a valid resolution
-    { D2DLL_D2CLIENT, { 0x6628F, 0xC452F }, PATCH_NOPBLOCK, FALSE, 7 },
-    { D2DLL_D2CLIENT, { 0x6628F, 0xC452F }, PATCH_CALL, FALSE, 0 },
-    { D2DLL_D2CLIENT, { 0x6628F + 1, 0xC452F + 1 }, (int)HD::SetResolutionModeOnGameStart_Interception, TRUE, 0 },
-
     { D2DLL_D2CLIENT, { 0x4446B, 0x454BB }, PATCH_NOPBLOCK, FALSE, 7 },
     { D2DLL_D2CLIENT, { 0x4446B, 0x454BB }, PATCH_CALL, FALSE, 0 },
-    { D2DLL_D2CLIENT, { 0x4446B + 1, 0x454BB + 1 }, (int)HD::SetResolutionModeOnGameStart_Interception, TRUE, 0 },
+    { D2DLL_D2CLIENT, { 0x4446B + 1, 0x454BB + 1 }, (int)HD::SetResolutionModeOnGameStart001_Interception, TRUE, 0 },
+
+    { D2DLL_D2CLIENT, { 0x6628F, 0xC452F }, PATCH_NOPBLOCK, FALSE, 7 },
+    { D2DLL_D2CLIENT, { 0x6628F, 0xC452F }, PATCH_CALL, FALSE, 0 },
+    { D2DLL_D2CLIENT, { 0x6628F + 1, 0xC452F + 1 }, (int)HD::SetResolutionModeOnGameStart002_Interception, TRUE, 0 },
 
     // Write to D2HD.ini Instead of Registry
     { D2DLL_D2CLIENT, { 0x662AB, 0xC454B }, PATCH_NOPBLOCK, FALSE, 0x662BC - 0x662AB },

--- a/D2Patch.h
+++ b/D2Patch.h
@@ -102,6 +102,14 @@ static const DLLPatchStrc gptTemplatePatches[] =
     { D2DLL_D2CLIENT, { 0x662AB, 0xC454B }, PATCH_CALL, FALSE, 0 },
     { D2DLL_D2CLIENT, { 0x662AB + 1, 0xC454B + 1 }, (int)HD::SaveRegistryResolution_Interception, TRUE, 0 },
 
+    { D2DLL_D2CLIENT, { 0x65E47, -1 }, PATCH_NOPBLOCK, FALSE, 0x662BC - 0x662AB },
+    { D2DLL_D2CLIENT, { 0x65E47, -1 }, PATCH_CALL, FALSE, 0 },
+    { D2DLL_D2CLIENT, { 0x65E47 + 1, -1 + 1 }, (int)HD::SaveRegistryResolution_Interception, TRUE, 0 },
+
+    { D2DLL_D2CLIENT, { 0xAF951, -1 }, PATCH_NOPBLOCK, FALSE, 0x6628A - 0x66279 },
+    { D2DLL_D2CLIENT, { 0xAF951, -1 }, PATCH_CALL, FALSE, 0 },
+    { D2DLL_D2CLIENT, { 0xAF951 + 1, -1 + 1 }, (int)HD::SaveRegistryResolution_Interception, TRUE, 0 },
+
     // Add New Resolutions Without Replacement
     { D2DLL_D2CLIENT, { 0x662C5, 0xC4565 }, PATCH_NOPBLOCK, FALSE, 7 },
     { D2DLL_D2CLIENT, { 0x662C5, 0xC4565 }, PATCH_CALL, FALSE, 0 },

--- a/DLLmain.cpp
+++ b/DLLmain.cpp
@@ -175,6 +175,7 @@ int __stdcall DllAttach()
     D2TEMPLATE_ApplyPatch(hGame, borderPanelClickDetectionPatches);
     D2TEMPLATE_ApplyPatch(hGame, drawPatches);
     D2TEMPLATE_ApplyPatch(hGame, inventoryPatches);
+
     if (Enable800ControlPanel) {
         D2TEMPLATE_ApplyPatch(hGame, controlPanel800Patches);
     }

--- a/HD/D2HDPatches.cpp
+++ b/HD/D2HDPatches.cpp
@@ -2,7 +2,7 @@
 #include "../D2Ptrs.h"
 
 int __stdcall GetNewResolutionId();
-int __stdcall GetNewResolutionOnGameStart();
+int __stdcall GetNewResolutionOnGameStart(int resolutionMode);
 int __stdcall SetupGlideRenderResolution();
 
 void __declspec(naked) HD::ResizeWindow_Interception() {
@@ -106,11 +106,29 @@ void __declspec(naked) HD::SetResolutionModeId_Interception() {
     }
 }
 
-void __declspec(naked) HD::SetResolutionModeOnGameStart_Interception() {
+void __declspec(naked) HD::SetResolutionModeOnGameStart001_Interception() {
     __asm {
         PUSH EAX
         PUSH ECX
+        ADD EAX, 01
+        PUSH EAX
         CALL[GetNewResolutionOnGameStart]
+        MOV ESI, EAX
+        POP ECX
+        POP EAX
+        RET
+    }
+}
+
+void __declspec(naked) HD::SetResolutionModeOnGameStart002_Interception() {
+    __asm {
+        PUSH EAX
+        PUSH ECX
+        PUSH EDI
+        ADD EDI, 01
+        PUSH EDI
+        CALL[GetNewResolutionOnGameStart]
+        POP EDI
         MOV ESI, EAX
         POP ECX
         POP EAX
@@ -132,8 +150,8 @@ int __stdcall GetNewResolutionId() {
     return mode;
 }
 
-int __stdcall GetNewResolutionOnGameStart() {
-    int mode = *D2CLIENT_CurrentRegistryResolutionMode;
+int __stdcall GetNewResolutionOnGameStart(int resolutionMode) {
+    int mode = resolutionMode;
 
     if (mode == 1) {
         return 2;

--- a/HD/D2HDPatches.h
+++ b/HD/D2HDPatches.h
@@ -8,7 +8,8 @@ namespace HD {
     void ResizeForgroundRenderWidth_Interception();
     void ResizeGameLogicResolution_Interception();
     void SetResolutionModeId_Interception();
-    void SetResolutionModeOnGameStart_Interception();
+    void SetResolutionModeOnGameStart001_Interception();
+    void SetResolutionModeOnGameStart002_Interception();
     void SetRegistryResolutionModeId_Interception();
     void SaveRegistryResolution_Interception(int mode);
     void LoadRegistryResolution_Interception(int* mode);


### PR DESCRIPTION
- Add extra patch calls for redirecting writes to registry to D2HD.ini. It is currently unknown if they do anything.
- Fix resolution lag when creating the first game.