### PR TITLE
Fix licensing

### DIFF
--- a/D2Constants.h
+++ b/D2Constants.h
@@ -1,12 +1,10 @@
-#pragma once
-
-#ifndef _D2CONSTANTS_H
-#define _D2CONSTANTS_H
-
 /****************************************************************************
 *                                                                           *
 *   D2Constants.h                                                           *
 *   Copyright (C) Olivier Verville                                          *
+*                                                                           *
+*   D2Ex: Copyright (c) 2011-2014 Bartosz Jankowski                         *
+*   /r/SlashDiablo HD Modifications: Copyright (C) 2017 Mir Drualga         *
 *                                                                           *
 *   Licensed under the Apache License, Version 2.0 (the "License");         *
 *   you may not use this file except in compliance with the License.        *
@@ -35,6 +33,11 @@
 *   this value, you only need to change your constant's value               *
 *                                                                           *
 *****************************************************************************/
+
+#pragma once
+
+#ifndef _D2CONSTANTS_H
+#define _D2CONSTANTS_H
 
 enum D2C_UnitTypes
 {

--- a/D2DataTables.h
+++ b/D2DataTables.h
@@ -1,14 +1,10 @@
-#pragma once
-
-#ifndef _D2DATATABLES_H
-#define _D2DATATABLES_H
-
-#pragma pack(1)
-
 /****************************************************************************
 *                                                                           *
 *   D2DataTables.h                                                          *
 *   Copyright (C) Olivier Verville                                          *
+*                                                                           *
+*   D2Ex: Copyright (c) 2011-2014 Bartosz Jankowski                         *
+*   /r/SlashDiablo HD Modifications: Copyright (C) 2017 Mir Drualga         *
 *                                                                           *
 *   Licensed under the Apache License, Version 2.0 (the "License");         *
 *   you may not use this file except in compliance with the License.        *
@@ -31,6 +27,13 @@
 *   by the game, such as Monstats.txt or Charstats.txt                      *
 *                                                                           *
 *****************************************************************************/
+
+#pragma once
+
+#ifndef _D2DATATABLES_H
+#define _D2DATATABLES_H
+
+#pragma pack(1)
 
 /****************************************************************************
 *                                                                           *

--- a/D2PacketDef.h
+++ b/D2PacketDef.h
@@ -1,14 +1,10 @@
-#pragma once
-
-#ifndef _D2PACKETDEF_H
-#define _D2PACKETDEF_H
-
-#pragma pack(1)
-
 /****************************************************************************
 *                                                                           *
 *   D2PacketDef.h                                                           *
 *   Copyright (C) Olivier Verville                                          *
+*                                                                           *
+*   D2Ex: Copyright (c) 2011-2014 Bartosz Jankowski                         *
+*   /r/SlashDiablo HD Modifications: Copyright (C) 2017 Mir Drualga         *
 *                                                                           *
 *   Licensed under the Apache License, Version 2.0 (the "License");         *
 *   you may not use this file except in compliance with the License.        *
@@ -31,6 +27,13 @@
 *   handle communications between the server and the client                 *
 *                                                                           *
 *****************************************************************************/
+
+#pragma once
+
+#ifndef _D2PACKETDEF_H
+#define _D2PACKETDEF_H
+
+#pragma pack(1)
 
 /****************************************************************************
 *                                                                           *

--- a/D2Patch.h
+++ b/D2Patch.h
@@ -1,14 +1,10 @@
-#pragma once
-
-#ifndef _D2PATCH_H
-#define _D2PATCH_H
-
-#include "D2PatchConst.h"
-
 /****************************************************************************
 *                                                                           *
 *   D2Patch.h                                                               *
 *   Copyright (C) Olivier Verville                                          *
+*                                                                           *
+*   D2Ex: Copyright (c) 2011-2014 Bartosz Jankowski                         *
+*   /r/SlashDiablo HD Modifications: Copyright (C) 2017 Mir Drualga         *
 *                                                                           *
 *   Licensed under the Apache License, Version 2.0 (the "License");         *
 *   you may not use this file except in compliance with the License.        *
@@ -31,6 +27,13 @@
 *   array, in order to be handled by D2Template's patcher                   *
 *                                                                           *
 *****************************************************************************/
+
+#pragma once
+
+#ifndef _D2PATCH_H
+#define _D2PATCH_H
+
+#include "D2PatchConst.h"
 
 static const DLLPatchStrc gptTemplatePatches[] =
 {

--- a/D2PatchConst.h
+++ b/D2PatchConst.h
@@ -1,8 +1,3 @@
-#pragma once
-
-#ifndef _D2PATCHCONST_H
-#define _D2PATCHCONST_H
-
 /****************************************************************************
 *                                                                           *
 *   D2PatchConst.h                                                          *
@@ -29,6 +24,11 @@
 *   know what you're doing.                                                 *
 *                                                                           *
 *****************************************************************************/
+
+#pragma once
+
+#ifndef _D2PATCHCONST_H
+#define _D2PATCHCONST_H
 
 #define PATCH_JMP               0x000000E9
 #define PATCH_CALL              0x000000E8

--- a/D2Ptrs.h
+++ b/D2Ptrs.h
@@ -1,11 +1,9 @@
-#pragma once
-
-#ifndef _D2PTRS_H
-#define _D2PTRS_H
-
 /****************************************************************************
 *                                                                           *
 *   D2Ptrs.h                                                                *
+*   Copyright (C) Olivier Verville                                          *
+*                                                                           *
+*   /r/SlashDiablo HD Modifications: Copyright (C) 2017 Mir Drualga         *
 *                                                                           *
 *   Licensed under the Apache License, Version 2.0 (the "License");         *
 *   you may not use this file except in compliance with the License.        *
@@ -31,6 +29,11 @@
 *   them by address can also end up being very useful                       *
 *                                                                           *
 *****************************************************************************/
+
+#pragma once
+
+#ifndef _D2PTRS_H
+#define _D2PTRS_H
 
 struct PointerOffset {
     int Pointer_113c;

--- a/D2Structs.h
+++ b/D2Structs.h
@@ -1,15 +1,10 @@
-#pragma once
-
-#ifndef _D2STRUCTS_H
-#define _D2STRUCTS_H
-
-#include "D2DataTables.h"
-#include "D2PacketDef.h"
-#pragma pack(1)
-
 /****************************************************************************
 *                                                                           *
 *   D2Structs.h                                                             *
+*   Copyright (C) Olivier Verville                                          *
+*                                                                           *
+*   D2Ex: Copyright (c) 2011-2014 Bartosz Jankowski                         *
+*   /r/SlashDiablo HD Modifications: Copyright (C) 2017 Mir Drualga         *
 *                                                                           *
 *   Licensed under the Apache License, Version 2.0 (the "License");         *
 *   you may not use this file except in compliance with the License.        *
@@ -32,6 +27,15 @@
 *   a unit entity, or a game entity                                         *
 *                                                                           *
 *****************************************************************************/
+
+#pragma once
+
+#ifndef _D2STRUCTS_H
+#define _D2STRUCTS_H
+
+#include "D2DataTables.h"
+#include "D2PacketDef.h"
+#pragma pack(1)
 
 /****************************************************************************
 *                                                                           *

--- a/D2Stubs.cpp
+++ b/D2Stubs.cpp
@@ -1,3 +1,27 @@
+/****************************************************************************
+*                                                                           *
+*   D2Stubs.cpp                                                             *
+*   Copyright (C) 2017 Mir Drualga                                          *
+*                                                                           *
+*   Licensed under the Apache License, Version 2.0 (the "License");         *
+*   you may not use this file except in compliance with the License.        *
+*   You may obtain a copy of the License at                                 *
+*                                                                           *
+*   http://www.apache.org/licenses/LICENSE-2.0                              *
+*                                                                           *
+*   Unless required by applicable law or agreed to in writing, software     *
+*   distributed under the License is distributed on an "AS IS" BASIS,       *
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.*
+*   See the License for the specific language governing permissions and     *
+*   limitations under the License.                                          *
+*                                                                           *
+*---------------------------------------------------------------------------*
+*                                                                           *
+*   Defines the functions that are used to help call functions in           *
+*   Diablo II that do not conform to standard calling conventions.          *
+*                                                                           *
+*****************************************************************************/
+
 #include "D2Stubs.h"
 
 __declspec(naked) CellFile* __stdcall STUB_D2CLIENT_LoadCellFile(const char* szBuffer) {

--- a/D2Stubs.h
+++ b/D2Stubs.h
@@ -1,7 +1,36 @@
+/****************************************************************************
+*                                                                           *
+*   D2Stubs.h                                                               *
+*   Copyright (C) 2017 Mir Drualga                                          *
+*                                                                           *
+*   D2Ex: Copyright (c) 2011-2014 Bartosz Jankowski                         *
+*                                                                           *
+*   Licensed under the Apache License, Version 2.0 (the "License");         *
+*   you may not use this file except in compliance with the License.        *
+*   You may obtain a copy of the License at                                 *
+*                                                                           *
+*   http://www.apache.org/licenses/LICENSE-2.0                              *
+*                                                                           *
+*   Unless required by applicable law or agreed to in writing, software     *
+*   distributed under the License is distributed on an "AS IS" BASIS,       *
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.*
+*   See the License for the specific language governing permissions and     *
+*   limitations under the License.                                          *
+*                                                                           *
+*---------------------------------------------------------------------------*
+*                                                                           *
+*   This file is used to declare stubs that will be used to call game       *
+*   functions that do not conform to STDCALL or FASTCALL conventions.       *
+*                                                                           *
+*   For example, a function that would need a stub function to be called    *
+*   would be one that puts the first parameter into register ESI.           *
+*                                                                           *
+*****************************************************************************/
+
 #pragma once
 
-#ifndef _D2STUBS_H
-#define _D2STUBS_H
+#ifndef D2STUBS_H
+#define D2STUBS_H
 
 #include "DLLmain.h"
 #include "D2Ptrs.h"

--- a/D2Vars.h
+++ b/D2Vars.h
@@ -1,16 +1,9 @@
-#pragma once
-
-#include "D2Structs.h"
-
-#ifdef _D2VARS_H
-#define VAR(Type, Name)         Type Name;
-#else
-#define VAR(Type, Name)         extern Type Name;
-#endif
-
 /****************************************************************************
 *                                                                           *
 *   D2Vars.h                                                                *
+*   Copyright (C) Olivier Verville                                          *
+*                                                                           *
+*   /r/SlashDiablo HD Modifications: Copyright (C) 2017 Mir Drualga         *
 *                                                                           *
 *   Licensed under the Apache License, Version 2.0 (the "License");         *
 *   you may not use this file except in compliance with the License.        *
@@ -32,6 +25,16 @@
 *   within your code. These variables can be used anywhere in your code     *
 *                                                                           *
 *****************************************************************************/
+
+#pragma once
+
+#include "D2Structs.h"
+
+#ifdef _D2VARS_H
+#define VAR(Type, Name)         Type Name;
+#else
+#define VAR(Type, Name)         extern Type Name;
+#endif
 
 VAR(DWORD, LeftPanelBackgroundColor)
 VAR(DWORD, LeftPanelBorderColor)

--- a/D2Version.cpp
+++ b/D2Version.cpp
@@ -1,3 +1,27 @@
+/****************************************************************************
+*                                                                           *
+*   D2Version.cpp                                                           *
+*   Copyright (C) 2017 Mir Drualga                                          *
+*                                                                           *
+*   Licensed under the Apache License, Version 2.0 (the "License");         *
+*   you may not use this file except in compliance with the License.        *
+*   You may obtain a copy of the License at                                 *
+*                                                                           *
+*   http://www.apache.org/licenses/LICENSE-2.0                              *
+*                                                                           *
+*   Unless required by applicable law or agreed to in writing, software     *
+*   distributed under the License is distributed on an "AS IS" BASIS,       *
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.*
+*   See the License for the specific language governing permissions and     *
+*   limitations under the License.                                          *
+*                                                                           *
+*---------------------------------------------------------------------------*
+*                                                                           *
+*   Defines the functions that are used for Diablo II Game.exe version      *
+*   detection.                                                              *
+*                                                                           *
+*****************************************************************************/
+
 #include "D2Version.h"
 #include <Windows.h>
 
@@ -34,19 +58,14 @@ std::string D2Version::GetGameVersionString() {
 
     std::string returnValue;
 
-    if (verSize != NULL)
-    {
+    if (verSize != NULL) {
         LPSTR verData = new char[verSize];
 
-        if (GetFileVersionInfo(szVersionFile, verHandle, verSize, verData))
-        {
-            if (VerQueryValue(verData, "\\", (VOID FAR* FAR*)&lpBuffer, &size))
-            {
-                if (size)
-                {
+        if (GetFileVersionInfo(szVersionFile, verHandle, verSize, verData)) {
+            if (VerQueryValue(verData, "\\", (VOID FAR* FAR*)&lpBuffer, &size)) {
+                if (size) {
                     VS_FIXEDFILEINFO *verInfo = (VS_FIXEDFILEINFO *)lpBuffer;
-                    if (verInfo->dwSignature == 0xfeef04bd)
-                    {
+                    if (verInfo->dwSignature == 0xfeef04bd) {
                         char szBuffer[MAX_PATH];
                         // Doesn't matter if you are on 32 bit or 64 bit,
                         // DWORD is always 32 bits, so first two revision numbers

--- a/D2Version.h
+++ b/D2Version.h
@@ -1,3 +1,27 @@
+/****************************************************************************
+*                                                                           *
+*   D2Version.h                                                             *
+*   Copyright (C) 2017 Mir Drualga                                          *
+*                                                                           *
+*   Licensed under the Apache License, Version 2.0 (the "License");         *
+*   you may not use this file except in compliance with the License.        *
+*   You may obtain a copy of the License at                                 *
+*                                                                           *
+*   http://www.apache.org/licenses/LICENSE-2.0                              *
+*                                                                           *
+*   Unless required by applicable law or agreed to in writing, software     *
+*   distributed under the License is distributed on an "AS IS" BASIS,       *
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.*
+*   See the License for the specific language governing permissions and     *
+*   limitations under the License.                                          *
+*                                                                           *
+*---------------------------------------------------------------------------*
+*                                                                           *
+*   This file is used to declare the functions and Diablo II versions that  *
+*   are to be detected from Game.exe.                                       *
+*                                                                           *
+*****************************************************************************/
+
 #pragma once
 
 #ifndef _D2VERSION_H

--- a/DLLmain.cpp
+++ b/DLLmain.cpp
@@ -1,11 +1,9 @@
-#define _D2VARS_H
-
-#include "DLLmain.h"
-#include "D2Patch.h"
-
 /****************************************************************************
 *                                                                           *
-*   DLLmain.h                                                               *
+*   DLLmain.cpp                                                             *
+*   Copyright (C) Olivier Verville                                          *
+*                                                                           *
+*   /r/SlashDiablo HD Modifications: Copyright (c) 2017 Mir Drualga         *
 *                                                                           *
 *   Licensed under the Apache License, Version 2.0 (the "License");         *
 *   you may not use this file except in compliance with the License.        *
@@ -26,6 +24,11 @@
 *   D2Template core file, do not modify unless you know what you're doing   *
 *                                                                           *
 *****************************************************************************/
+
+#define _D2VARS_H
+
+#include "DLLmain.h"
+#include "D2Patch.h"
 
 void __fastcall D2TEMPLATE_FatalError(char* szMessage)
 {

--- a/DLLmain.h
+++ b/DLLmain.h
@@ -1,6 +1,9 @@
 /****************************************************************************
 *                                                                           *
 *   DLLmain.h                                                               *
+*   Copyright (C) Olivier Verville                                          *
+*                                                                           *
+*   /r/SlashDiablo HD Modifications: Copyright (C) 2017 Mir Drualga         *
 *                                                                           *
 *   Licensed under the Apache License, Version 2.0 (the "License");         *
 *   you may not use this file except in compliance with the License.        *

--- a/HD/D2HDConfig.cpp
+++ b/HD/D2HDConfig.cpp
@@ -1,3 +1,29 @@
+/****************************************************************************
+*                                                                           *
+*   D2HDConfig.cpp                                                          *
+*   Copyright (C) 2017 Mir Drualga                                          *
+*                                                                           *
+*   Licensed under the Apache License, Version 2.0 (the "License");         *
+*   you may not use this file except in compliance with the License.        *
+*   You may obtain a copy of the License at                                 *
+*                                                                           *
+*   http://www.apache.org/licenses/LICENSE-2.0                              *
+*                                                                           *
+*   Unless required by applicable law or agreed to in writing, software     *
+*   distributed under the License is distributed on an "AS IS" BASIS,       *
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.*
+*   See the License for the specific language governing permissions and     *
+*   limitations under the License.                                          *
+*                                                                           *
+*---------------------------------------------------------------------------*
+*                                                                           *
+*   Defines the functions that read and write to a configuration file.      *
+*   By default, this file is D2HD.ini.                                      *
+*                                                                           *
+*   This file can be modified to add more configuration options.            *
+*                                                                           *
+*****************************************************************************/
+
 #include "D2HDConfig.h"
 
 std::string Config::archiveName;

--- a/HD/D2HDConfig.h
+++ b/HD/D2HDConfig.h
@@ -1,24 +1,42 @@
+/****************************************************************************
+*                                                                           *
+*   D2HDConfig.h                                                            *
+*   Copyright (C) 2017 Mir Drualga                                          *
+*                                                                           *
+*   Licensed under the Apache License, Version 2.0 (the "License");         *
+*   you may not use this file except in compliance with the License.        *
+*   You may obtain a copy of the License at                                 *
+*                                                                           *
+*   http://www.apache.org/licenses/LICENSE-2.0                              *
+*                                                                           *
+*   Unless required by applicable law or agreed to in writing, software     *
+*   distributed under the License is distributed on an "AS IS" BASIS,       *
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.*
+*   See the License for the specific language governing permissions and     *
+*   limitations under the License.                                          *
+*                                                                           *
+*---------------------------------------------------------------------------*
+*                                                                           *
+*   Declares functions that read and write to a configuration file.         *
+*   By default, this file is D2HD.ini.                                      *
+*                                                                           *
+*   It is here that mod-makers can modify macros to apply acceptable        *
+*   settings for their users. One such important setting specifies the      *
+*   number of custom resolutions available, including the first two         *
+*   standard resolutions.                                                   *
+*                                                                           *
+*****************************************************************************/
+
 #pragma once
+
+#ifndef D2HDCONFIG_H
+#define D2HDCONFIG_H
 
 #include <Windows.h>
 #include <string>
 #include <sstream>
 #include "D2HDStructs.h"
 #include "../D2Vars.h"
-
-/*
-    It is here that mod-makers can modify macros to apply acceptable
-    settings for their users.
-*/
-
-/*
-    To define your own custom replacement for 640x480, simply
-    change the values of the definition below.
-
-    I highly do NOT recommend changing the 800x600 values. The
-    values you place are overriden in the D2GDI code and messes
-    everything up.
-*/
 
 #define RESOLUTION_640_TO_HD_WIDTH 1068
 #define RESOLUTION_640_TO_HD_HEIGHT 600
@@ -36,6 +54,10 @@
 */
 #define USE_CUSTOM_MPQ_FILE 0
 
+/*
+    Determines the number of custom resolutions available. This
+    includes the first two standard resolutions.
+*/
 #define NUMBER_OF_CUSTOM_RESOLUTIONS 4
 
 namespace Config {
@@ -49,3 +71,5 @@ namespace Config {
     void __stdcall WriteRegistryResolution(int mode);
     void __stdcall ReadRegistryResolution(int* mode);
 }
+
+#endif

--- a/HD/D2HDDraw.cpp
+++ b/HD/D2HDDraw.cpp
@@ -1,3 +1,30 @@
+/****************************************************************************
+*                                                                           *
+*   D2HDDraw.cpp                                                            *
+*   Copyright (C) 2017 Mir Drualga                                          *
+*                                                                           *
+*   D2Ex: Copyright (c) 2011-2014 Bartosz Jankowski                         *
+*                                                                           *
+*   Licensed under the Apache License, Version 2.0 (the "License");         *
+*   you may not use this file except in compliance with the License.        *
+*   You may obtain a copy of the License at                                 *
+*                                                                           *
+*   http://www.apache.org/licenses/LICENSE-2.0                              *
+*                                                                           *
+*   Unless required by applicable law or agreed to in writing, software     *
+*   distributed under the License is distributed on an "AS IS" BASIS,       *
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.*
+*   See the License for the specific language governing permissions and     *
+*   limitations under the License.                                          *
+*                                                                           *
+*---------------------------------------------------------------------------*
+*                                                                           *
+*   Defines the functions that corrects standard Diablo II draw functions   *
+*   to work with higher resolutions. It also defines new draw calls to      *
+*   imitate the look of D2MultiRes.                                         *
+*                                                                           *
+*****************************************************************************/
+
 #include "D2HDDraw.h"
 #include "../DLLmain.h"
 #include "../D2Ptrs.h"

--- a/HD/D2HDDraw.h
+++ b/HD/D2HDDraw.h
@@ -1,3 +1,30 @@
+/****************************************************************************
+*                                                                           *
+*   D2HDDraw.h                                                              *
+*   Copyright (C) 2017 Mir Drualga                                          *
+*                                                                           *
+*   D2Ex: Copyright (c) 2011-2014 Bartosz Jankowski                         *
+*                                                                           *
+*   Licensed under the Apache License, Version 2.0 (the "License");         *
+*   you may not use this file except in compliance with the License.        *
+*   You may obtain a copy of the License at                                 *
+*                                                                           *
+*   http://www.apache.org/licenses/LICENSE-2.0                              *
+*                                                                           *
+*   Unless required by applicable law or agreed to in writing, software     *
+*   distributed under the License is distributed on an "AS IS" BASIS,       *
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.*
+*   See the License for the specific language governing permissions and     *
+*   limitations under the License.                                          *
+*                                                                           *
+*---------------------------------------------------------------------------*
+*                                                                           *
+*   Declares the functions that corrects standard Diablo II draw functions  *
+*   to work with higher resolutions. It also declares new draw calls to     *
+*   imitate the look of D2MultiRes.                                         *
+*                                                                           *
+*****************************************************************************/
+
 /*
     Many thanks to the creator of D2MultiRes and the person who revealed its source on BlizzHackers.
     In addition, thanks to the creators of D2Ex2 for publicly hosting their own code, which helped
@@ -5,6 +32,9 @@
 */
 
 #pragma once
+
+#ifndef D2HDDRAW_H
+#define D2HDDRAW_H
 
 namespace HD {
     void RedrawUILeftPanelBorders();
@@ -17,3 +47,5 @@ namespace HD {
     void STUB_DetermineText();
     void* DetermineText();
 }
+
+#endif

--- a/HD/D2HDInventory.cpp
+++ b/HD/D2HDInventory.cpp
@@ -1,3 +1,24 @@
+/*==========================================================
+* D2Ex2
+* https://github.com/lolet/D2Ex2
+* ==========================================================
+* Copyright (c) 2011-2014 Bartosz Jankowski
+* /r/SlashDiablo HD Modifications: Copyright (c) 2017 Mir Drualga
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* ==========================================================
+*/
+
 #include "D2HDInventory.h"
 #include "../D2Ptrs.h"
 

--- a/HD/D2HDInventory.h
+++ b/HD/D2HDInventory.h
@@ -1,11 +1,30 @@
+/*==========================================================
+* D2Ex2
+* https://github.com/lolet/D2Ex2
+* ==========================================================
+* Copyright (c) 2011-2014 Bartosz Jankowski
+* /r/SlashDiablo HD Modifications: Copyright (c) 2017 Mir Drualga
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* ==========================================================
+*/
+
 #pragma once
 
-#include "../DLLmain.h"
+#ifndef D2HDINVENTORY_H
+#define D2HDINVENTORY_H
 
-/*
-    All code was taken directly from D2Ex. I researched nothing and I deserve nothing for this
-    section.
-*/
+#include "../DLLmain.h"
 
 namespace Inventory {
     void __stdcall GetBeltPos(int nIndex, int nMode, BeltBox *out, int nBox);
@@ -14,3 +33,5 @@ namespace Inventory {
     void __stdcall GetInventoryGrid(int nRecord, int nScreenMode, InventoryGrid *pOut);
     void __stdcall GetInventoryField(int nRecord, int nScreenMode, InventoryLayout *pOut, int nField);
 }
+
+#endif

--- a/HD/D2HDPatches.cpp
+++ b/HD/D2HDPatches.cpp
@@ -1,3 +1,29 @@
+/****************************************************************************
+*                                                                           *
+*   D2HDPatches.cpp                                                         *
+*   Copyright (C) 2017 Mir Drualga                                          *
+*                                                                           *
+*   D2Ex: Copyright (c) 2011-2014 Bartosz Jankowski                         *
+*                                                                           *
+*   Licensed under the Apache License, Version 2.0 (the "License");         *
+*   you may not use this file except in compliance with the License.        *
+*   You may obtain a copy of the License at                                 *
+*                                                                           *
+*   http://www.apache.org/licenses/LICENSE-2.0                              *
+*                                                                           *
+*   Unless required by applicable law or agreed to in writing, software     *
+*   distributed under the License is distributed on an "AS IS" BASIS,       *
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.*
+*   See the License for the specific language governing permissions and     *
+*   limitations under the License.                                          *
+*                                                                           *
+*---------------------------------------------------------------------------*
+*                                                                           *
+*   Defines the functions that expands Diablo II's standard functions to    *
+*   allow changing to and using custom resolutions.                         *
+*                                                                           *
+*****************************************************************************/
+
 #include "D2HDPatches.h"
 #include "../D2Ptrs.h"
 

--- a/HD/D2HDPatches.h
+++ b/HD/D2HDPatches.h
@@ -1,3 +1,34 @@
+/****************************************************************************
+*                                                                           *
+*   D2HDPatches.h                                                           *
+*   Copyright (C) 2017 Mir Drualga                                          *
+*                                                                           *
+*   D2Ex: Copyright (c) 2011-2014 Bartosz Jankowski                         *
+*                                                                           *
+*   Licensed under the Apache License, Version 2.0 (the "License");         *
+*   you may not use this file except in compliance with the License.        *
+*   You may obtain a copy of the License at                                 *
+*                                                                           *
+*   http://www.apache.org/licenses/LICENSE-2.0                              *
+*                                                                           *
+*   Unless required by applicable law or agreed to in writing, software     *
+*   distributed under the License is distributed on an "AS IS" BASIS,       *
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.*
+*   See the License for the specific language governing permissions and     *
+*   limitations under the License.                                          *
+*                                                                           *
+*---------------------------------------------------------------------------*
+*                                                                           *
+*   Declares the functions that expands Diablo II's standard functions to   *
+*   allow changing to and using custom resolutions.                         *
+*                                                                           *
+*****************************************************************************/
+
+#pragma once
+
+#ifndef D2HDPATCHES_H
+#define D2HDPATCHES_H
+
 #include "../DLLmain.h"
 
 namespace HD {
@@ -24,3 +55,5 @@ namespace HD {
 
     int __stdcall GetResolutionMode_Patch();
 }
+
+#endif

--- a/HD/D2HDStructs.cpp
+++ b/HD/D2HDStructs.cpp
@@ -1,3 +1,28 @@
+/****************************************************************************
+*                                                                           *
+*   D2HDStructs.cpp                                                         *
+*   Copyright (C) 2017 Mir Drualga                                          *
+*                                                                           *
+*   D2Ex: Copyright (c) 2011-2014 Bartosz Jankowski                         *
+*                                                                           *
+*   Licensed under the Apache License, Version 2.0 (the "License");         *
+*   you may not use this file except in compliance with the License.        *
+*   You may obtain a copy of the License at                                 *
+*                                                                           *
+*   http://www.apache.org/licenses/LICENSE-2.0                              *
+*                                                                           *
+*   Unless required by applicable law or agreed to in writing, software     *
+*   distributed under the License is distributed on an "AS IS" BASIS,       *
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.*
+*   See the License for the specific language governing permissions and     *
+*   limitations under the License.                                          *
+*                                                                           *
+*---------------------------------------------------------------------------*
+*                                                                           *
+*   Defines custom structs that are used by this mod.                       *
+*                                                                           *
+*****************************************************************************/
+
 #include "D2HDStructs.h"
 
 DWORD Color::FormatRGBtoBGR(RGBFormat* format) {

--- a/HD/D2HDStructs.h
+++ b/HD/D2HDStructs.h
@@ -1,4 +1,32 @@
+/****************************************************************************
+*                                                                           *
+*   D2HDStructs.h                                                           *
+*   Copyright (C) 2017 Mir Drualga                                          *
+*                                                                           *
+*   D2Ex: Copyright (c) 2011-2014 Bartosz Jankowski                         *
+*                                                                           *
+*   Licensed under the Apache License, Version 2.0 (the "License");         *
+*   you may not use this file except in compliance with the License.        *
+*   You may obtain a copy of the License at                                 *
+*                                                                           *
+*   http://www.apache.org/licenses/LICENSE-2.0                              *
+*                                                                           *
+*   Unless required by applicable law or agreed to in writing, software     *
+*   distributed under the License is distributed on an "AS IS" BASIS,       *
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.*
+*   See the License for the specific language governing permissions and     *
+*   limitations under the License.                                          *
+*                                                                           *
+*---------------------------------------------------------------------------*
+*                                                                           *
+*   Declares custom structs that are used by this mod.                      *
+*                                                                           *
+*****************************************************************************/
+
 #pragma once
+
+#ifndef D2HDSTRUCTS_H
+#define D2HDSTRUCTS_H
 
 #include <Windows.h>
 #include <string>
@@ -15,3 +43,5 @@ namespace Color {
     DWORD FormatRGBtoBGR(DWORD color);
     DWORD FormatRGBtoBGR(std::string color);
 }
+
+#endif

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2015 Olivier Verville
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/TemplateIncludes.h
+++ b/TemplateIncludes.h
@@ -1,11 +1,9 @@
-#pragma once
-
-#ifndef _TEMPLATEINCLUDES_H
-#define _TEMPLATEINCLUDES_H
-
 /****************************************************************************
 *                                                                           *
-*   DLLmain.h                                                               *
+*   TemplateIncludes.h                                                      *
+*   Copyright (C) Olivier Verville                                          *
+*                                                                           *
+*   /r/SlashDiablo HD Modifications: Copyright (C) 2017 Mir Drualga         *
 *                                                                           *
 *   Licensed under the Apache License, Version 2.0 (the "License");         *
 *   you may not use this file except in compliance with the License.        *
@@ -26,6 +24,11 @@
 *   This file is where you include new headers in your codebase             *
 *                                                                           *
 *****************************************************************************/
+
+#pragma once
+
+#ifndef _TEMPLATEINCLUDES_H
+#define _TEMPLATEINCLUDES_H
 
 #include "HD/D2HDPatches.h"
 #include "HD/D2HDStructs.h"


### PR DESCRIPTION
Correct licensing in LICENSE file and boilerplate headers.
- Properly credit D2Ex and olivierverville.
- Add include guards.