### PR TITLE
Cleanup

### DIFF
--- a/D2Ptrs.h
+++ b/D2Ptrs.h
@@ -46,7 +46,7 @@ struct PointerOffset {
 //  These are the macros used by the template core to declare                                                                                                                                   ///
 //  pointers. Do not touch unless you know what you're doing                                                                                                                                    ///
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-#define OFFSET(DLL, NAME, DEFTYPE) *(&##DLL##_##NAME##_##DEFTYPE##_POINTERS.Pointer_113c + D2Version::GetGameVersionID())
+#define OFFSET(DLL, NAME, DEFTYPE) *(&##DLL##_##NAME##_##DEFTYPE##_POINTERS.Pointer_113c + ((int)D2Version::GetGameVersionID()))
 
 #define D2FUNC(DLL, NAME, RETURN, CONV, ARGS, ...) \
     static PointerOffset DLL##_##NAME##_D2FUNC_POINTERS = { __VA_ARGS__ }; \

--- a/D2Vars.h
+++ b/D2Vars.h
@@ -65,6 +65,8 @@ VAR(CellFile*, D2MRFancyPanelLeft)
 VAR(CellFile*, D2MRFancyPanelRight)
 VAR(CellFile*, D2MRFancyVerticalBar)
 VAR(CellFile*, Blank)
+VAR(CellFile*, Resolution1068x600Text)
+VAR(CellFile*, Resolution1344x700Text)
 
 // end of file ---------------------------------------------------------------
 #undef _D2VARS_H

--- a/D2Vars.h
+++ b/D2Vars.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "D2Structs.h"
+#include "HD/D2HDColor.h"
 
 #ifdef _D2VARS_H
 #define VAR(Type, Name)         Type Name;
@@ -36,10 +37,10 @@
 #define VAR(Type, Name)         extern Type Name;
 #endif
 
-VAR(DWORD, LeftPanelBackgroundColor)
-VAR(DWORD, LeftPanelBorderColor)
-VAR(DWORD, RightPanelBorderColor)
-VAR(DWORD, RightPanelBackgroundColor)
+VAR(HD::D2HDColor, LeftPanelBackgroundColor)
+VAR(HD::D2HDColor, LeftPanelBorderColor)
+VAR(HD::D2HDColor, RightPanelBorderColor)
+VAR(HD::D2HDColor, RightPanelBackgroundColor)
 
 VAR(BOOL, EnableD2MRPanelBorderStyle)
 VAR(BOOL, InvertD2MRControlPanel)

--- a/D2Version.cpp
+++ b/D2Version.cpp
@@ -28,30 +28,85 @@
 
 #pragma comment(lib,"Version.lib")
 
-VersionID D2Version::versionID = INVALID;
+D2Version::GameVersionID D2Version::gameVersionID = D2Version::GameVersionID::INVALID;
+D2Version::Glide3xVersionID D2Version::glide3xVersionID = D2Version::Glide3xVersionID::INVALID;
 
 void D2Version::Init() {
-    std::string version = GetGameVersionString();
+    std::string gameVersion = GetGameVersionString();
 
-    if (version == "1.0.13.60") {
-        versionID = VERSION_113c;
-    } else if (version == "1.0.13.64") {
-        versionID = VERSION_113d;
+    if (gameVersion == "1.0.13.60") {
+        gameVersionID = GameVersionID::VERSION_113c;
+    } else if (gameVersion == "1.0.13.64") {
+        gameVersionID = GameVersionID::VERSION_113d;
     } else {
-        versionID = INVALID;
+        gameVersionID = GameVersionID::INVALID;
+    }
+
+    std::string glide3xVersion = GetGlide3xVersionString();
+
+    if (glide3xVersion == "1.4.4.21") {
+        glide3xVersionID = Glide3xVersionID::VERSION_14e;
+    } else if (glide3xVersion == "1.4.8.2") {
+        glide3xVersionID = Glide3xVersionID::RESURGENCE;
+    } else {
+        glide3xVersionID = Glide3xVersionID::INVALID;
     }
 }
 
-VersionID D2Version::GetGameVersionID() {
-    if (versionID == INVALID) {
+D2Version::GameVersionID D2Version::GetGameVersionID() {
+    if (gameVersionID == GameVersionID::INVALID) {
         Init();
     }
-    return versionID;
+    return gameVersionID;
+}
+
+D2Version::Glide3xVersionID D2Version::GetGlide3xVersionID() {
+    if (glide3xVersionID == Glide3xVersionID::INVALID) {
+        Init();
+    }
+    return glide3xVersionID;
 }
 
 // Taken from StackOverflow user crashmstr
 std::string D2Version::GetGameVersionString() {
     LPSTR szVersionFile = "Game.exe";
+    DWORD  verHandle = 0;
+    UINT   size = 0;
+    LPBYTE lpBuffer = NULL;
+    DWORD  verSize = GetFileVersionInfoSize(szVersionFile, &verHandle);
+
+    std::string returnValue;
+
+    if (verSize != NULL) {
+        LPSTR verData = new char[verSize];
+
+        if (GetFileVersionInfo(szVersionFile, verHandle, verSize, verData)) {
+            if (VerQueryValue(verData, "\\", (VOID FAR* FAR*)&lpBuffer, &size)) {
+                if (size) {
+                    VS_FIXEDFILEINFO *verInfo = (VS_FIXEDFILEINFO *)lpBuffer;
+                    if (verInfo->dwSignature == 0xfeef04bd) {
+                        // Doesn't matter if you are on 32 bit or 64 bit,
+                        // DWORD is always 32 bits, so first two revision numbers
+                        // come from dwFileVersionMS, last two come from dwFileVersionLS
+                        std::ostringstream stringStream;
+
+                        stringStream << ((verInfo->dwFileVersionMS >> 16) & 0xffff) << ".";
+                        stringStream << ((verInfo->dwFileVersionMS >> 0) & 0xffff) << ".";
+                        stringStream << ((verInfo->dwFileVersionLS >> 16) & 0xffff) << ".";
+                        stringStream << ((verInfo->dwFileVersionLS >> 0) & 0xffff);
+
+                        returnValue = stringStream.str();
+                    }
+                }
+            }
+        }
+        delete[] verData;
+    }
+    return returnValue;
+}
+
+std::string D2Version::GetGlide3xVersionString() {
+    LPSTR szVersionFile = "glide3x.dll";
     DWORD  verHandle = 0;
     UINT   size = 0;
     LPBYTE lpBuffer = NULL;

--- a/D2Version.h
+++ b/D2Version.h
@@ -29,17 +29,26 @@
 
 #include <string>
 
-enum VersionID {
-    INVALID = -1,
-    VERSION_113c = 0,
-    VERSION_113d
-};
-
 namespace D2Version {
-    extern VersionID versionID;
-    VersionID GetGameVersionID();
+    enum class GameVersionID {
+        INVALID = -1,
+        VERSION_113c = 0,
+        VERSION_113d
+    };
+
+    enum class Glide3xVersionID {
+        INVALID,
+        VERSION_14e,
+        RESURGENCE
+    };
+
+    extern GameVersionID gameVersionID;
+    extern Glide3xVersionID glide3xVersionID;
+    GameVersionID GetGameVersionID();
+    Glide3xVersionID GetGlide3xVersionID();
     void Init();
     std::string GetGameVersionString();
+    std::string GetGlide3xVersionString();
 };
 
 #endif

--- a/DLLmain.cpp
+++ b/DLLmain.cpp
@@ -38,8 +38,13 @@ void __fastcall D2TEMPLATE_FatalError(char* szMessage)
 
 BOOL __fastcall D2TEMPLATE_ApplyPatch(void* hGame, const DLLPatchStrc* hPatch)
 {
-    if (D2Version::versionID == INVALID) {
+    if (D2Version::GetGameVersionID() == D2Version::GameVersionID::INVALID) {
         int response = MessageBoxA(nullptr, "D2HD currently does not support this version of Diablo II.", "Unsupported Game Version", MB_OK | MB_ICONSTOP);
+        exit(1);
+    }
+
+    if (D2Version::GetGlide3xVersionID() == D2Version::Glide3xVersionID::INVALID) {
+        int response = MessageBoxA(nullptr, "Glide3x.dll version not supported. Make sure to use the latest supported version.", "Unsupported Glide3x.dll Version", MB_OK | MB_ICONSTOP);
         exit(1);
     }
 
@@ -49,7 +54,7 @@ BOOL __fastcall D2TEMPLATE_ApplyPatch(void* hGame, const DLLPatchStrc* hPatch)
         int nDLL = hPatch->nDLL;
         if (nDLL < 0 || nDLL >= D2DLL_INVALID) return FALSE;
 
-        int offset = *(&hPatch->stAddresses.Pointer_113c + D2Version::versionID);
+        int offset = *(&hPatch->stAddresses.Pointer_113c + ((int)D2Version::gameVersionID));
         if (!offset) return FALSE;
 
         DWORD dwBaseAddress = gptDllFiles[nDLL].dwAddress;
@@ -173,7 +178,9 @@ int __stdcall DllAttach()
     }
 #endif
 
-    D2TEMPLATE_ApplyPatch(hGame, glide3xPatches);
+    if (D2Version::GetGlide3xVersionID() == D2Version::Glide3xVersionID::VERSION_14e) {
+        D2TEMPLATE_ApplyPatch(hGame, glide3xPatches);
+    }
     D2TEMPLATE_ApplyPatch(hGame, gptTemplatePatches);
     D2TEMPLATE_ApplyPatch(hGame, borderPanelClickDetectionPatches);
     D2TEMPLATE_ApplyPatch(hGame, drawPatches);

--- a/HD/D2HD.vcxproj
+++ b/HD/D2HD.vcxproj
@@ -24,6 +24,7 @@
     <ClInclude Include="..\DLLmain.h" />
     <ClInclude Include="..\Resource.h" />
     <ClInclude Include="..\TemplateIncludes.h" />
+    <ClInclude Include="D2HDColor.h" />
     <ClInclude Include="D2HDConfig.h" />
     <ClInclude Include="D2HDInventory.h" />
     <ClInclude Include="D2HDPatches.h" />
@@ -34,6 +35,7 @@
     <ClCompile Include="..\D2Stubs.cpp" />
     <ClCompile Include="..\D2Version.cpp" />
     <ClCompile Include="..\DLLmain.cpp" />
+    <ClCompile Include="D2HDColor.cpp" />
     <ClCompile Include="D2HDConfig.cpp" />
     <ClCompile Include="D2HDInventory.cpp" />
     <ClCompile Include="D2HDPatches.cpp" />

--- a/HD/D2HD.vcxproj.filters
+++ b/HD/D2HD.vcxproj.filters
@@ -72,6 +72,9 @@
     <ClInclude Include="..\Resource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="D2HDColor.h">
+      <Filter>D2HD</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\DLLmain.cpp">
@@ -97,6 +100,9 @@
     </ClCompile>
     <ClCompile Include="..\D2Version.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="D2HDColor.cpp">
+      <Filter>D2HD</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/HD/D2HDColor.cpp
+++ b/HD/D2HDColor.cpp
@@ -1,0 +1,84 @@
+/****************************************************************************
+*                                                                           *
+*   D2HDColor.cpp                                                           *
+*   Copyright (C) 2017 Mir Drualga                                          *
+*                                                                           *
+*   Licensed under the Apache License, Version 2.0 (the "License");         *
+*   you may not use this file except in compliance with the License.        *
+*   You may obtain a copy of the License at                                 *
+*                                                                           *
+*   http://www.apache.org/licenses/LICENSE-2.0                              *
+*                                                                           *
+*   Unless required by applicable law or agreed to in writing, software     *
+*   distributed under the License is distributed on an "AS IS" BASIS,       *
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.*
+*   See the License for the specific language governing permissions and     *
+*   limitations under the License.                                          *
+*                                                                           *
+*---------------------------------------------------------------------------*
+*                                                                           *
+*   Defines a custom class that performs conversions of Diablo II color     *
+*   representations of BGR to RGB, and vice versa.                          *
+*                                                                           *
+*****************************************************************************/
+
+#include "D2HDColor.h"
+
+#include <Windows.h>
+#include <sstream>
+#include <string>
+
+HD::D2HDColor::D2HDColor() : HD::D2HDColor::D2HDColor(255, 255, 255, 255) {
+}
+
+HD::D2HDColor::D2HDColor(std::string color) {
+    DWORD colorValue = std::stoul(color, NULL, 16);
+    
+    D2HDColor::red = (colorValue >> (8 * 3)) & 0xFF;
+    D2HDColor::green = (colorValue >> (8 * 2)) & 0xFF;
+    D2HDColor::blue = (colorValue >> (8 * 1)) & 0xFF;
+    D2HDColor::tint = colorValue & 0xFF;
+}
+
+HD::D2HDColor::D2HDColor(unsigned char red, unsigned char green, unsigned char blue, unsigned char tint) {
+    D2HDColor::red = red;
+    D2HDColor::green = green;
+    D2HDColor::blue = blue;
+    D2HDColor::tint = tint;
+}
+
+DWORD HD::D2HDColor::getRGBFormat() {
+    DWORD redRGB = (((DWORD)red) << (8 * 3)) & 0xFF000000;
+    DWORD greenRGB = ((DWORD)green << (8 * 2)) & 0x00FF0000;
+    DWORD blueRGB = ((DWORD)blue << (8 * 1)) & 0x0000FF00;
+    DWORD tintRGB = ((DWORD)tint) & 0x000000FF;
+
+    return redRGB | greenRGB | blueRGB | tintRGB;
+}
+
+DWORD HD::D2HDColor::getBGRFormat() {
+    DWORD redBGR = (((DWORD)red) << (8 * 1)) & 0x0000FF00;
+    DWORD greenBGR = (((DWORD)green) << (8 * 2)) & 0x00FF0000;
+    DWORD blueBGR = ((DWORD)blue << (8 * 3)) & 0xFF000000;
+    DWORD tintBGR = ((DWORD)tint) & 0x000000FF;
+
+    return redBGR | greenBGR | blueBGR | tintBGR;
+}
+
+HD::D2HDColor HD::D2HDColor::createFromRGBFormat(DWORD color) {
+    unsigned char red = (((DWORD)color) >> (8 * 3)) & 0xFF;
+    unsigned char green = (((DWORD)color) >> (8 * 2)) & 0xFF;
+    unsigned char blue = (((DWORD)color) >> (8 * 1)) & 0xFF;
+    unsigned char tint = color & 0xFF;
+
+    return HD::D2HDColor(red, green, blue, tint);
+}
+
+HD::D2HDColor HD::D2HDColor::createFromBGRFormat(DWORD color) {
+    unsigned char red = (((DWORD)color) >> (8 * 1)) & 0xFF;
+    unsigned char green = (((DWORD)color) >> (8 * 2)) & 0xFF;
+    unsigned char blue = (((DWORD)color) >> (8 * 3)) & 0xFF;
+    unsigned char tint = ((DWORD)color) & 0xFF;
+
+    return HD::D2HDColor(red, green, blue, tint);
+}

--- a/HD/D2HDColor.h
+++ b/HD/D2HDColor.h
@@ -1,8 +1,7 @@
 /****************************************************************************
 *                                                                           *
-*   D2HDStructs.cpp                                                         *
+*   D2HDColor.h                                                             *
 *   Copyright (C) 2017 Mir Drualga                                          *
-*                                                                           *
 *                                                                           *
 *   Licensed under the Apache License, Version 2.0 (the "License");         *
 *   you may not use this file except in compliance with the License.        *
@@ -18,8 +17,36 @@
 *                                                                           *
 *---------------------------------------------------------------------------*
 *                                                                           *
-*   Defines custom structs that are used by this mod.                       *
+*   Declares a custom class that performs conversions of Diablo II color    *
+*   representations of BGR to RGB, and vice versa.                          *
 *                                                                           *
 *****************************************************************************/
 
-#include "D2HDStructs.h"
+#pragma once
+
+#ifndef D2HDCOLOR_H
+#define D2HDCOLOR_H
+
+#include <Windows.h>
+#include <string>
+
+namespace HD {
+    class D2HDColor {
+    private:
+        unsigned char red;
+        unsigned char green;
+        unsigned char blue;
+        unsigned char tint;
+
+    public:
+        D2HDColor();
+        D2HDColor(std::string color);
+        D2HDColor(unsigned char red, unsigned char green, unsigned char blue, unsigned char tint);
+        DWORD getBGRFormat();
+        DWORD getRGBFormat();
+        static D2HDColor createFromRGBFormat(DWORD color);
+        static D2HDColor createFromBGRFormat(DWORD color);
+    };
+}
+
+#endif

--- a/HD/D2HDConfig.cpp
+++ b/HD/D2HDConfig.cpp
@@ -25,6 +25,7 @@
 *****************************************************************************/
 
 #include "D2HDConfig.h"
+#include "D2HDColor.h"
 
 std::string Config::archiveName;
 std::string Config::configPath = "./D2HD.ini";
@@ -52,17 +53,17 @@ void Config::ReadMainSettings() {
 
     const DWORD defaultColor = 0xFFFFFFFF;
 
-    DWORD tempColor = ReadColor(sectionName, "Left Panel Background Color", defaultColor);
-    LeftPanelBackgroundColor = Color::FormatRGBtoBGR(tempColor);
+    DWORD rgbColor = ReadColor(sectionName, "Left Panel Background Color", defaultColor);
+    LeftPanelBackgroundColor = HD::D2HDColor::createFromRGBFormat(rgbColor);
 
-    tempColor = ReadColor(sectionName, "Left Panel Border Color", defaultColor);
-    LeftPanelBorderColor = Color::FormatRGBtoBGR(tempColor);
+    rgbColor = ReadColor(sectionName, "Left Panel Border Color", defaultColor);
+    LeftPanelBorderColor = HD::D2HDColor::createFromRGBFormat(rgbColor);
 
-    tempColor = ReadColor(sectionName, "Right Panel Border Color", defaultColor);
-    RightPanelBorderColor = Color::FormatRGBtoBGR(tempColor);
+    rgbColor = ReadColor(sectionName, "Right Panel Border Color", defaultColor);
+    RightPanelBorderColor = HD::D2HDColor::createFromRGBFormat(rgbColor);
 
-    tempColor = ReadColor(sectionName, "Right Panel Background Color", defaultColor);
-    RightPanelBackgroundColor = Color::FormatRGBtoBGR(tempColor);
+    rgbColor = ReadColor(sectionName, "Right Panel Background Color", defaultColor);
+    RightPanelBackgroundColor = HD::D2HDColor::createFromRGBFormat(rgbColor);
 
     EnableD2MRPanelBorderStyle = GetPrivateProfileIntA(sectionName.c_str(), "Enable D2MR Border Panel Style", true, configPath.c_str());
     if (EnableD2MRPanelBorderStyle == true) {

--- a/HD/D2HDConfig.cpp
+++ b/HD/D2HDConfig.cpp
@@ -90,18 +90,24 @@ void Config::ReadMainSettings() {
         WritePrivateProfileStringA(sectionName.c_str(), "Resolution", "0", configPath.c_str());
     }
 
-    CustomWidth = GetPrivateProfileIntA(sectionName.c_str(), "Custom Width (can't be larger than 1344)", 1068, configPath.c_str());
-    if (CustomWidth == 1068) {
-        WritePrivateProfileStringA(sectionName.c_str(), "Custom Width (can't be larger than 1344)", "1068", configPath.c_str());
-    } else if (CustomWidth >= 1344 || CustomWidth < 320) {
-        CustomWidth = 1344;
+    std::ostringstream customWidthText;
+    customWidthText << "Custom Width (can't be larger than " << MAXIMUM_WIDTH << ")";
+
+    CustomWidth = GetPrivateProfileIntA(sectionName.c_str(), customWidthText.str().c_str(), 0, configPath.c_str());
+    if (CustomWidth == 0) {
+        WritePrivateProfileStringA(sectionName.c_str(), customWidthText.str().c_str(), "1068", configPath.c_str());
+    } else if (CustomWidth >= MAXIMUM_WIDTH || CustomWidth < 320) {
+        CustomWidth = MAXIMUM_WIDTH;
     }
 
-    CustomHeight = GetPrivateProfileIntA(sectionName.c_str(), "Custom Height (can't be larger than 700)", 600, configPath.c_str());
+    std::ostringstream customHeightText;
+    customHeightText << "Custom Height (can't be larger than " << MAXIMUM_HEIGHT << ")";
+
+    CustomHeight = GetPrivateProfileIntA(sectionName.c_str(), customHeightText.str().c_str(), 600, configPath.c_str());
     if (CustomHeight == 600) {
-        WritePrivateProfileStringA(sectionName.c_str(), "Custom Height (can't be larger than 700)", "600", configPath.c_str());
-    } else if (CustomHeight >= 700 || CustomHeight < 240) {
-        CustomHeight = 700;
+        WritePrivateProfileStringA(sectionName.c_str(), customHeightText.str().c_str(), "600", configPath.c_str());
+    } else if (CustomHeight >= MAXIMUM_HEIGHT || CustomHeight < 240) {
+        CustomHeight = MAXIMUM_HEIGHT;
     }
 }
 

--- a/HD/D2HDConfig.h
+++ b/HD/D2HDConfig.h
@@ -45,13 +45,16 @@
 */
 #define USE_CUSTOM_MPQ_FILE 1
 
-/*
-    Determines the number of custom resolutions available. This
-    includes the first two standard resolutions.
-*/
-#define NUMBER_OF_CUSTOM_RESOLUTIONS 4
-
 namespace Config {
+    const DWORD MAXIMUM_WIDTH = 1344;
+    const DWORD MAXIMUM_HEIGHT = 700;
+
+    /*
+    *     Determines the number of custom resolutions available. This
+    *     includes the first two standard resolutions.
+    */
+    const DWORD NUMBER_OF_CUSTOM_RESOLUTIONS = 4;
+
     extern std::string configPath;
     extern std::string archiveName;
 

--- a/HD/D2HDDraw.cpp
+++ b/HD/D2HDDraw.cpp
@@ -85,9 +85,9 @@ void RedrawUIRightPanelBorders_D2MR() {
     borderTop.nFrame = 0;
     borderTop.pCellFile = D2MRFancyBorderTop;
 
-    D2GFX_DrawCellContext(&borderTop, (basePositionX + 60), (basePositionY + 60), RightPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderTop, (basePositionX + 60), (basePositionY + 60), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
     borderTop.nFrame++;
-    D2GFX_DrawCellContext(&borderTop, (basePositionX + 60) + 256, (basePositionY + 60), RightPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderTop, (basePositionX + 60) + 256, (basePositionY + 60), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
 
 
     // Draw bottom border pieces
@@ -95,28 +95,28 @@ void RedrawUIRightPanelBorders_D2MR() {
     borderBottom.nFrame = 0;
     borderBottom.pCellFile = D2MRFancyBorderBottom;
 
-    D2GFX_DrawCellContext(&borderBottom, (basePositionX + 60), (basePositionY + 256) + (256 + 40), RightPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderBottom, (basePositionX + 60), (basePositionY + 256) + (256 + 40), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
     borderBottom.nFrame++;
-    D2GFX_DrawCellContext(&borderBottom, (basePositionX + 60) + 256, (basePositionY + 256) + (256 + 40), RightPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderBottom, (basePositionX + 60) + 256, (basePositionY + 256) + (256 + 40), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
 
     // Draw corner border pieces
     CellContext borderCorner = { 0 };
     borderCorner.nFrame = 0;
     borderCorner.pCellFile = D2MRFancyBorderCorner;
 
-    D2GFX_DrawCellContext(&borderCorner, (basePositionX), (basePositionY + 60), RightPanelBorderColor, 5, nullptr);
-    D2GFX_DrawCellContext(&borderCorner, (basePositionX), (basePositionY + 256) + (256 + 40), RightPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderCorner, (basePositionX), (basePositionY + 60), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
+    D2GFX_DrawCellContext(&borderCorner, (basePositionX), (basePositionY + 256) + (256 + 40), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
 
     // Draw left border pieces
     CellContext borderRight = { 0 };
     borderRight.nFrame = 0;
     borderRight.pCellFile = D2MRFancyBorderInterfaceRight;
 
-    D2GFX_DrawCellContext(&borderRight, (basePositionX + 320), (basePositionY + 256), RightPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderRight, (basePositionX + 320), (basePositionY + 256), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
     borderRight.nFrame++;
-    D2GFX_DrawCellContext(&borderRight, (basePositionX + 320), (basePositionY + 256) + 256, RightPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderRight, (basePositionX + 320), (basePositionY + 256) + 256, RightPanelBorderColor.getBGRFormat(), 5, nullptr);
     borderRight.nFrame++;
-    D2GFX_DrawCellContext(&borderRight, (basePositionX + 320), (basePositionY + 256) + (256 + 40), RightPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderRight, (basePositionX + 320), (basePositionY + 256) + (256 + 40), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
 }
 
 void RedrawUIRightPanelBorders_Original() {
@@ -132,23 +132,23 @@ void RedrawUIRightPanelBorders_Original() {
     int basePositionY = (*D2CLIENT_ScreenSizeY / 2) - 300;
 
     // Frame 5
-    D2GFX_DrawCellContext(&cellContext, basePositionX, basePositionY + 63, RightPanelBorderColor, 5, 0);
+    D2GFX_DrawCellContext(&cellContext, basePositionX, basePositionY + 63, RightPanelBorderColor.getBGRFormat(), 5, 0);
     cellContext.nFrame++;
 
     // Frame 6
-    D2GFX_DrawCellContext(&cellContext, basePositionX + 144, basePositionY + 253, RightPanelBorderColor, 5, 0);
+    D2GFX_DrawCellContext(&cellContext, basePositionX + 144, basePositionY + 253, RightPanelBorderColor.getBGRFormat(), 5, 0);
     cellContext.nFrame++;
 
     // Frame 7
-    D2GFX_DrawCellContext(&cellContext, basePositionX + 313, basePositionY + 484, RightPanelBorderColor, 5, 0);
+    D2GFX_DrawCellContext(&cellContext, basePositionX + 313, basePositionY + 484, RightPanelBorderColor.getBGRFormat(), 5, 0);
     cellContext.nFrame++;
 
     // Frame 8
-    D2GFX_DrawCellContext(&cellContext, basePositionX + 144, basePositionY + 553, RightPanelBorderColor, 5, 0);
+    D2GFX_DrawCellContext(&cellContext, basePositionX + 144, basePositionY + 553, RightPanelBorderColor.getBGRFormat(), 5, 0);
     cellContext.nFrame++;
 
     // Frame 9
-    D2GFX_DrawCellContext(&cellContext, basePositionX, basePositionY + 553, RightPanelBorderColor, 5, 0);
+    D2GFX_DrawCellContext(&cellContext, basePositionX, basePositionY + 553, RightPanelBorderColor.getBGRFormat(), 5, 0);
     cellContext.nFrame++;
 }
 
@@ -165,23 +165,23 @@ void RedrawUILeftPanelBorders_Original() {
     cellContext.nFrame = 0;
 
     // Frame 0
-    D2GFX_DrawCellContext(&cellContext, basePositionX, basePositionY + 253, LeftPanelBorderColor, 5, 0);
+    D2GFX_DrawCellContext(&cellContext, basePositionX, basePositionY + 253, LeftPanelBorderColor.getBGRFormat(), 5, 0);
     cellContext.nFrame++;
 
     // Frame 1
-    D2GFX_DrawCellContext(&cellContext, basePositionX + 256, basePositionY + 63, LeftPanelBorderColor, 5, 0);
+    D2GFX_DrawCellContext(&cellContext, basePositionX + 256, basePositionY + 63, LeftPanelBorderColor.getBGRFormat(), 5, 0);
     cellContext.nFrame++;
 
     // Frame 2
-    D2GFX_DrawCellContext(&cellContext, basePositionX, basePositionY + 484, LeftPanelBorderColor, 5, 0);
+    D2GFX_DrawCellContext(&cellContext, basePositionX, basePositionY + 484, LeftPanelBorderColor.getBGRFormat(), 5, 0);
     cellContext.nFrame++;
 
     // Frame 3
-    D2GFX_DrawCellContext(&cellContext, basePositionX, basePositionY + 553, LeftPanelBorderColor, 5, 0);
+    D2GFX_DrawCellContext(&cellContext, basePositionX, basePositionY + 553, LeftPanelBorderColor.getBGRFormat(), 5, 0);
     cellContext.nFrame++;
 
     // Frame 4
-    D2GFX_DrawCellContext(&cellContext, basePositionX + 256, basePositionY + 553, LeftPanelBorderColor, 5, 0);
+    D2GFX_DrawCellContext(&cellContext, basePositionX + 256, basePositionY + 553, LeftPanelBorderColor.getBGRFormat(), 5, 0);
     cellContext.nFrame++;
 }
 
@@ -207,9 +207,9 @@ void RedrawUILeftPanelBorders_D2MR() {
     borderTop.nFrame = 0;
     borderTop.pCellFile = D2MRFancyBorderTop;
 
-    D2GFX_DrawCellContext(&borderTop, (basePositionX + 56), (basePositionY + 60), LeftPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderTop, (basePositionX + 56), (basePositionY + 60), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
     borderTop.nFrame++;
-    D2GFX_DrawCellContext(&borderTop, (basePositionX + 56) + 256, (basePositionY + 60), LeftPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderTop, (basePositionX + 56) + 256, (basePositionY + 60), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
 
 
     // Draw bottom border pieces
@@ -217,28 +217,28 @@ void RedrawUILeftPanelBorders_D2MR() {
     borderBottom.nFrame = 0;
     borderBottom.pCellFile = D2MRFancyBorderBottom;
 
-    D2GFX_DrawCellContext(&borderBottom, (basePositionX + 56), (basePositionY + 256) + (256 + 40), LeftPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderBottom, (basePositionX + 56), (basePositionY + 256) + (256 + 40), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
     borderBottom.nFrame++;
-    D2GFX_DrawCellContext(&borderBottom, (basePositionX + 56) + 256, (basePositionY + 256) + (256 + 40), LeftPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderBottom, (basePositionX + 56) + 256, (basePositionY + 256) + (256 + 40), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
 
     // Draw corner border pieces
     CellContext borderCorner = { 0 };
     borderCorner.nFrame = 0;
     borderCorner.pCellFile = D2MRFancyBorderCorner;
 
-    D2GFX_DrawCellContext(&borderCorner, (basePositionX + 56) + 284, (basePositionY + 60), LeftPanelBorderColor, 5, nullptr);
-    D2GFX_DrawCellContext(&borderCorner, (basePositionX + 56) + 284, (basePositionY)+(256 + 256 + 40), LeftPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderCorner, (basePositionX + 56) + 284, (basePositionY + 60), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
+    D2GFX_DrawCellContext(&borderCorner, (basePositionX + 56) + 284, (basePositionY)+(256 + 256 + 40), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
 
     // Draw left border pieces
     CellContext borderLeft = { 0 };
     borderLeft.nFrame = 0;
     borderLeft.pCellFile = D2MRFancyBorderInterfaceLeft;
 
-    D2GFX_DrawCellContext(&borderLeft, basePositionX, (basePositionY + 256), LeftPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderLeft, basePositionX, (basePositionY + 256), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
     borderLeft.nFrame++;
-    D2GFX_DrawCellContext(&borderLeft, basePositionX, (basePositionY + 256) + 256, LeftPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderLeft, basePositionX, (basePositionY + 256) + 256, LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
     borderLeft.nFrame++;
-    D2GFX_DrawCellContext(&borderLeft, basePositionX, (basePositionY + 256) + (256 + 40), LeftPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderLeft, basePositionX, (basePositionY + 256) + (256 + 40), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
 }
 
 void __declspec(naked) HD::STUB_DrawUIPanelBackground() {
@@ -299,7 +299,7 @@ void DrawUILeftPanelBackground() {
             image.nFrame = ((row % 2) * 2) + (col % 2);
             DWORD backBasePositionX = basePositionX - ((col + 1) * backWidth);
 
-            D2GFX_DrawCellContext(&image, backBasePositionX, backBasePositionY, LeftPanelBackgroundColor, 5, nullptr);
+            D2GFX_DrawCellContext(&image, backBasePositionX, backBasePositionY, LeftPanelBackgroundColor.getBGRFormat(), 5, nullptr);
         }
     }
 
@@ -327,40 +327,40 @@ void DrawUILeftPanelBackground() {
     borderLeft.pCellFile = D2MRFancyBorderLeft;
     borderLeft.nFrame = 0;
 
-    D2GFX_DrawCellContext(&borderLeft, (basePositionX - 60), (basePositionY + 256) + (256 + 256 + 40), LeftPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderLeft, (basePositionX - 60), (basePositionY + 256) + (256 + 256 + 40), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
     borderLeft.nFrame++;
-    D2GFX_DrawCellContext(&borderLeft, (basePositionX - 60), (basePositionY + 256 + 28), LeftPanelBorderColor, 5, nullptr);
-    D2GFX_DrawCellContext(&borderLeft, (basePositionX - 60), (basePositionY), LeftPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderLeft, (basePositionX - 60), (basePositionY + 256 + 28), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
+    D2GFX_DrawCellContext(&borderLeft, (basePositionX - 60), (basePositionY), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
     borderLeft.nFrame--;
-    D2GFX_DrawCellContext(&borderLeft, (basePositionX - 60), (basePositionY - 28), LeftPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderLeft, (basePositionX - 60), (basePositionY - 28), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
 
     CellContext horizontalBar = { 0 };
     horizontalBar.pCellFile = D2MRFancyHorizontalBar;
     horizontalBar.nFrame = 2;
 
-    D2GFX_DrawCellContext(&horizontalBar, (basePositionX - 400 - 35), (basePositionY + (256 + 256 + 40)), LeftPanelBorderColor, 5, nullptr);
-    D2GFX_DrawCellContext(&horizontalBar, (basePositionX - 400 - 35), (basePositionY + 60), LeftPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&horizontalBar, (basePositionX - 400 - 35), (basePositionY + (256 + 256 + 40)), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
+    D2GFX_DrawCellContext(&horizontalBar, (basePositionX - 400 - 35), (basePositionY + 60), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
 
     for (int i = 0; (basePositionX - 400 - 35) - (i * 256) >= 0; i++) {
         horizontalBar.nFrame = std::abs(i - 1) % 2;
-        D2GFX_DrawCellContext(&horizontalBar, (basePositionX - 400 - 35) - ((i + 1) * 256), (basePositionY + (256 + 256 + 40)), LeftPanelBorderColor, 5, nullptr);
-        D2GFX_DrawCellContext(&horizontalBar, (basePositionX - 400 - 35) - ((i + 1) * 256), (basePositionY + 60), LeftPanelBorderColor, 5, nullptr);
+        D2GFX_DrawCellContext(&horizontalBar, (basePositionX - 400 - 35) - ((i + 1) * 256), (basePositionY + (256 + 256 + 40)), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
+        D2GFX_DrawCellContext(&horizontalBar, (basePositionX - 400 - 35) - ((i + 1) * 256), (basePositionY + 60), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
     }
 
     CellContext verticalBar = { 0 };
     verticalBar.pCellFile = D2MRFancyVerticalBar;
     verticalBar.nFrame = 2;
 
-    D2GFX_DrawCellContext(&verticalBar, (basePositionX - 400), (basePositionY), LeftPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&verticalBar, (basePositionX - 400), (basePositionY), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
 
     for (int i = 0; ((basePositionY - 35) - (i * 256)) >= 0; i++) {
         verticalBar.nFrame = std::abs(i - 1) % 2;
-        D2GFX_DrawCellContext(&verticalBar, (basePositionX - 400), ((basePositionY - 35) - (i * 256)), LeftPanelBorderColor, 5, nullptr);
+        D2GFX_DrawCellContext(&verticalBar, (basePositionX - 400), ((basePositionY - 35) - (i * 256)), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
     }
 
     for (int i = 0; ((basePositionY + (256 + 256 + 40)) + (i * 256)) < (*D2CLIENT_ScreenSizeY); i++) {
         verticalBar.nFrame = i % 2;
-        D2GFX_DrawCellContext(&verticalBar, (basePositionX - 400), ((basePositionY + (256 + 256 + 40)) + ((i + 1) * 256)), LeftPanelBorderColor, 5, nullptr);
+        D2GFX_DrawCellContext(&verticalBar, (basePositionX - 400), ((basePositionY + (256 + 256 + 40)) + ((i + 1) * 256)), LeftPanelBorderColor.getBGRFormat(), 5, nullptr);
     }
 }
 
@@ -386,7 +386,7 @@ void DrawUIRightPanelBackground() {
             image.nFrame = ((row % 2) * 2) + ((col + 1) % 2);
             DWORD backBasePositionX = basePositionX + (col * backWidth);
 
-            D2GFX_DrawCellContext(&image, backBasePositionX, backBasePositionY, RightPanelBackgroundColor, 5, 0);
+            D2GFX_DrawCellContext(&image, backBasePositionX, backBasePositionY, RightPanelBackgroundColor.getBGRFormat(), 5, 0);
         }
     }
 
@@ -414,36 +414,36 @@ void DrawUIRightPanelBackground() {
     borderRight.pCellFile = D2MRFancyBorderRight;
     borderRight.nFrame = 0;
 
-    D2GFX_DrawCellContext(&borderRight, (basePositionX), (basePositionY + 256) + (256 + 256 + 40), RightPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderRight, (basePositionX), (basePositionY + 256) + (256 + 256 + 40), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
     borderRight.nFrame++;
-    D2GFX_DrawCellContext(&borderRight, (basePositionX), (basePositionY + 256 + 28), RightPanelBorderColor, 5, nullptr);
-    D2GFX_DrawCellContext(&borderRight, (basePositionX), (basePositionY), RightPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderRight, (basePositionX), (basePositionY + 256 + 28), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
+    D2GFX_DrawCellContext(&borderRight, (basePositionX), (basePositionY), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
     borderRight.nFrame--;
-    D2GFX_DrawCellContext(&borderRight, (basePositionX), (basePositionY - 28), RightPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&borderRight, (basePositionX), (basePositionY - 28), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
 
     CellContext horizontalBar = { 0 };
     horizontalBar.pCellFile = D2MRFancyHorizontalBar;
 
     for (int i = 0; (basePositionX + 400) + (i * 256) < (*D2CLIENT_ScreenSizeX); i++) {
         horizontalBar.nFrame = i % 2;
-        D2GFX_DrawCellContext(&horizontalBar, (basePositionX + 400) + (i * 256), (basePositionY + (256 + 256 + 40)), RightPanelBorderColor, 5, nullptr);
-        D2GFX_DrawCellContext(&horizontalBar, (basePositionX + 400) + (i * 256), (basePositionY + 60), RightPanelBorderColor, 5, nullptr);
+        D2GFX_DrawCellContext(&horizontalBar, (basePositionX + 400) + (i * 256), (basePositionY + (256 + 256 + 40)), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
+        D2GFX_DrawCellContext(&horizontalBar, (basePositionX + 400) + (i * 256), (basePositionY + 60), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
     }
 
     CellContext verticalBar = { 0 };
     verticalBar.pCellFile = D2MRFancyVerticalBar;
     verticalBar.nFrame = 2;
 
-    D2GFX_DrawCellContext(&verticalBar, (basePositionX + 400 - 60), (basePositionY), RightPanelBorderColor, 5, nullptr);
+    D2GFX_DrawCellContext(&verticalBar, (basePositionX + 400 - 60), (basePositionY), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
 
     for (int i = 0; ((basePositionY - 35) - (i * 256)) >= 0; i++) {
         verticalBar.nFrame = std::abs(i - 1) % 2;
-        D2GFX_DrawCellContext(&verticalBar, (basePositionX + 400 - 60), ((basePositionY - 35) - (i * 256)), RightPanelBorderColor, 5, nullptr);
+        D2GFX_DrawCellContext(&verticalBar, (basePositionX + 400 - 60), ((basePositionY - 35) - (i * 256)), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
     }
 
     for (int i = 0; ((basePositionY + (256 + 256 + 40)) + (i * 256)) < (*D2CLIENT_ScreenSizeY); i++) {
         verticalBar.nFrame = i % 2;
-        D2GFX_DrawCellContext(&verticalBar, (basePositionX + 400 - 60), ((basePositionY + (256 + 256 + 40)) + ((i + 1) * 256)), RightPanelBorderColor, 5, nullptr);
+        D2GFX_DrawCellContext(&verticalBar, (basePositionX + 400 - 60), ((basePositionY + (256 + 256 + 40)) + ((i + 1) * 256)), RightPanelBorderColor.getBGRFormat(), 5, nullptr);
     }
 }
 

--- a/HD/D2HDDraw.cpp
+++ b/HD/D2HDDraw.cpp
@@ -562,8 +562,24 @@ void* HD::DetermineText() {
         Blank = D2WIN_LoadCellFile("data\\local\\UI\\ENG\\Blank", 0);
     }
 
-    if (*D2CLIENT_CurrentRegistryResolutionMode >= 3 && assetValueA == D2CLIENT_VideoOptionCellFileStart && assetValueB == 0x154) {
-        returnValue = Blank;
+    if (Resolution1068x600Text == nullptr) {
+        Resolution1068x600Text = D2WIN_LoadCellFile("data\\local\\UI\\ENG\\1068x600", 0);
+    }
+
+    if (Resolution1344x700Text == nullptr) {
+        Resolution1344x700Text = D2WIN_LoadCellFile("data\\local\\UI\\ENG\\1344x700", 0);
+    }
+
+    if (assetValueA == D2CLIENT_VideoOptionCellFileStart && assetValueB == 0x154) {
+        if ((*D2CLIENT_ScreenSizeX == 640 && *D2CLIENT_ScreenSizeY == 480) || (*D2CLIENT_ScreenSizeX == 800 && *D2CLIENT_ScreenSizeY == 600)) {
+            returnValue = assetValueC;
+        } else if (*D2CLIENT_ScreenSizeX == 1068 && *D2CLIENT_ScreenSizeY == 600) {
+            returnValue = Resolution1068x600Text;
+        } else if (*D2CLIENT_ScreenSizeX == 1344 && *D2CLIENT_ScreenSizeY == 700) {
+            returnValue = Resolution1344x700Text;
+        } else {
+            returnValue = Blank;
+        }
     } else {
         returnValue = assetValueC;
     }

--- a/HD/D2HDDraw.cpp
+++ b/HD/D2HDDraw.cpp
@@ -516,6 +516,8 @@ void UnloadCellFiles() {
     UnloadCellFile(&D2MRFancyPanelRight);
     UnloadCellFile(&D2MRFancyVerticalBar);
     UnloadCellFile(&Blank);
+    UnloadCellFile(&Resolution1068x600Text);
+    UnloadCellFile(&Resolution1344x700Text);
 }
 
 void __declspec(naked) HD::STUB_UnloadCellFiles() {

--- a/HD/D2HDPatches.cpp
+++ b/HD/D2HDPatches.cpp
@@ -295,6 +295,11 @@ int __stdcall SetupGlideRenderResolution() {
         break;
     }
 
+    // Apply special case for /r/Diablo2Resurgence
+    if (D2Version::GetGlide3xVersionID() == D2Version::Glide3xVersionID::RESURGENCE && *D2GLIDE_ScreenSizeX == 1068 && *D2GLIDE_ScreenSizeY == 600) {
+        glideVideoMode = 0xFF;
+    }
+
     return glideVideoMode;
 }
 

--- a/HD/D2HDPatches.cpp
+++ b/HD/D2HDPatches.cpp
@@ -63,8 +63,8 @@ void __stdcall HD::D2GFX_GetModeParams(int mode, DWORD* width, DWORD* height) {
         break;
 
     case 3:
-        *width = 1344;
-        *height = 700;
+        *width = Config::MAXIMUM_WIDTH;
+        *height = Config::MAXIMUM_HEIGHT;
         break;
 
     case 4:
@@ -165,7 +165,7 @@ void __declspec(naked) HD::SetResolutionModeOnGameStart002_Interception() {
 int __stdcall GetNewResolutionId() {
     int mode = D2GFX_GetResolutionMode();
 
-    if (mode >= NUMBER_OF_CUSTOM_RESOLUTIONS) {
+    if (mode >= Config::NUMBER_OF_CUSTOM_RESOLUTIONS) {
         mode = 0;
     } else if (mode == 0) {
         mode = 2;

--- a/HD/D2HDStructs.h
+++ b/HD/D2HDStructs.h
@@ -31,17 +31,4 @@
 #include <Windows.h>
 #include <string>
 
-namespace Color {
-    struct RGBFormat {
-        unsigned char red;
-        unsigned char green;
-        unsigned char blue;
-        unsigned char tint;
-    };
-
-    DWORD FormatRGBtoBGR(RGBFormat* format);
-    DWORD FormatRGBtoBGR(DWORD color);
-    DWORD FormatRGBtoBGR(std::string color);
-}
-
 #endif


### PR DESCRIPTION
- D2HDColor is a separate class, to simply work for programmers.
- Add Glide3x.dll version detection, to prevent people in Resurgence from installing the vanilla glide3x.dll file and not gettingthe correct resolutions.
- Add resolution menu text for 1068x600 and 1344x700 in vanilla.
- Simplify definitions of the maximum width and higher, to simplify work for programmers.