### PR TITLE
Change License to AGPL v3+

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
@@ -7,17 +7,15 @@
 
                             Preamble
 
-  The GNU General Public License is a free, copyleft license for
-software and other kinds of works.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
   The licenses for most software and other practical works are designed
 to take away your freedom to share and change the works.  By contrast,
-the GNU General Public License is intended to guarantee your freedom to
+our General Public Licenses are intended to guarantee your freedom to
 share and change all versions of a program--to make sure it remains free
-software for all its users.  We, the Free Software Foundation, use the
-GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors.  You can apply it to
-your programs, too.
+software for all its users.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
@@ -26,44 +24,34 @@ them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
 free programs, and that you know you can do these things.
 
-  To protect your rights, we need to prevent others from denying you
-these rights or asking you to surrender the rights.  Therefore, you have
-certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-  For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must pass on to the recipients the same
-freedoms that you received.  You must make sure that they, too, receive
-or can get the source code.  And you must show them these terms so they
-know their rights.
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-  Developers that use the GNU GPL protect your rights with two steps:
-(1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-  For the developers' and authors' protection, the GPL clearly explains
-that there is no warranty for this free software.  For both users' and
-authors' sake, the GPL requires that modified versions be marked as
-changed, so that their problems will not be attributed erroneously to
-authors of previous versions.
-
-  Some devices are designed to deny users access to install or run
-modified versions of the software inside them, although the manufacturer
-can do so.  This is fundamentally incompatible with the aim of
-protecting users' freedom to change the software.  The systematic
-pattern of such abuse occurs in the area of products for individuals to
-use, which is precisely where it is most unacceptable.  Therefore, we
-have designed this version of the GPL to prohibit the practice for those
-products.  If such problems arise substantially in other domains, we
-stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.
-
-  Finally, every program is threatened constantly by software patents.
-States should not allow patents to restrict development and use of
-software on general-purpose computers, but in those that do, we wish to
-avoid the special danger that patents applied to a free program could
-make it effectively proprietary.  To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
@@ -72,7 +60,7 @@ modification follow.
 
   0. Definitions.
 
-  "This License" refers to version 3 of the GNU General Public License.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
   "Copyright" also means copyright-like laws that apply to other kinds of
 works, such as semiconductor masks.
@@ -549,35 +537,45 @@ to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
 
-  13. Use with the GNU Affero General Public License.
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
 
   Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a single
+under version 3 of the GNU General Public License into a single
 combined work, and to convey the resulting work.  The terms of this
 License will continue to apply to the part which is the covered work,
-but the special requirements of the GNU Affero General Public License,
-section 13, concerning interaction through a network will apply to the
-combination as such.
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
 
   14. Revised Versions of this License.
 
   The Free Software Foundation may publish revised and/or new versions of
-the GNU General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
   Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU General
+Program specifies that a certain numbered version of the GNU Affero General
 Public License "or any later version" applies to it, you have the
 option of following the terms and conditions either of that numbered
 version or of any later version published by the Free Software
 Foundation.  If the Program does not specify a version number of the
-GNU General Public License, you may choose any version ever published
+GNU Affero General Public License, you may choose any version ever published
 by the Free Software Foundation.
 
   If the Program specifies that a proxy can decide which future
-versions of the GNU General Public License can be used, that proxy's
+versions of the GNU Affero General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
 to choose that version for the Program.
 
@@ -635,40 +633,29 @@ the "copyright" line and a pointer to where the full notice is found.
     Copyright (C) 2017  Mir Drualga
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
+    You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-  If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:
-
-    SlashDiablo HD  Copyright (C) 2017  Mir Drualga
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an "about box".
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
 
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
+For more information on this, and how to apply and follow the GNU AGPL, see
 <http://www.gnu.org/licenses/>.
-
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/src/D2Constants.h
+++ b/src/D2Constants.h
@@ -1,22 +1,22 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *****************************************************************************/
 
 /*****************************************************************************
  *                                                                           *

--- a/src/D2DataTables.h
+++ b/src/D2DataTables.h
@@ -1,22 +1,22 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *****************************************************************************/
 
 /*****************************************************************************
  *                                                                           *

--- a/src/D2HD/D2HDCellContext.cpp
+++ b/src/D2HD/D2HDCellContext.cpp
@@ -1,28 +1,28 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   Defines a class that provides higher level abstraction for            *
- *   CellContext, for the purpose of allowing it to work on different      *
- *   versions of the game.                                                 *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   Defines a class that provides higher level abstraction for              *
+ *   CellContext, for the purpose of allowing it to work on different        *
+ *   versions of the game.                                                   *
+ *                                                                           *
+ *****************************************************************************/
 
 /*==========================================================
 * D2Ex2

--- a/src/D2HD/D2HDCellContext.h
+++ b/src/D2HD/D2HDCellContext.h
@@ -1,28 +1,28 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   Declares a class that provides higher level abstraction for           *
- *   CellContext, for the purpose of allowing it to work on different      *
- *   versions of the game.                                                 *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   Declares a class that provides higher level abstraction for             *
+ *   CellContext, for the purpose of allowing it to work on different        *
+ *   versions of the game.                                                   *
+ *                                                                           *
+ *****************************************************************************/
 
 /*==========================================================
 * D2Ex2

--- a/src/D2HD/D2HDColor.cpp
+++ b/src/D2HD/D2HDColor.cpp
@@ -1,27 +1,27 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   Defines a custom class that performs conversions of Diablo II color   *
- *   representations of BGR to RGB, and vice versa.                        *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   Defines a custom class that performs conversions of Diablo II color     *
+ *   representations of BGR to RGB, and vice versa.                          *
+ *                                                                           *
+ *****************************************************************************/
 
 #include "D2HDColor.h"
 

--- a/src/D2HD/D2HDColor.h
+++ b/src/D2HD/D2HDColor.h
@@ -1,27 +1,27 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   Declares a custom class that performs conversions of Diablo II color  *
- *   representations of BGR to RGB, and vice versa.                        *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   Declares a custom class that performs conversions of Diablo II color    *
+ *   representations of BGR to RGB, and vice versa.                          *
+ *                                                                           *
+ *****************************************************************************/
 
 #pragma once
 

--- a/src/D2HD/D2HDConfig.cpp
+++ b/src/D2HD/D2HDConfig.cpp
@@ -1,28 +1,28 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   Defines the functions that read and write to a configuration file.    *
- *                                                                         *
- *   This file can be modified to add more configuration options.          *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   Defines the functions that read and write to a configuration file.      *
+ *                                                                           *
+ *   This file can be modified to add more configuration options.            *
+ *                                                                           *
+ *****************************************************************************/
 
 #include "D2HDConfig.h"
 

--- a/src/D2HD/D2HDConfig.h
+++ b/src/D2HD/D2HDConfig.h
@@ -1,31 +1,31 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   Declares functions that read and write to a configuration file.       *
- *                                                                         *
- *   It is here that mod-makers can modify macros to apply acceptable      *
- *   settings for their users. One such important setting specifies the    *
- *   number of custom resolutions available, including the first two       *
- *   standard resolutions.                                                 *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   Declares functions that read and write to a configuration file.         *
+ *                                                                           *
+ *   It is here that mod-makers can modify macros to apply acceptable        *
+ *   settings for their users. One such important setting specifies the      *
+ *   number of custom resolutions available, including the first two         *
+ *   standard resolutions.                                                   *
+ *                                                                           *
+ *****************************************************************************/
 
 #pragma once
 

--- a/src/D2HD/D2HDConfigInterception.S
+++ b/src/D2HD/D2HDConfigInterception.S
@@ -1,28 +1,28 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   Defines the interception functions that are to be used when there is  *
- *   a need to replace Diablo II code with code that is declared under the *
- *   configurations scope.                                                 *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   Defines the interception functions that are to be used when there is    *
+ *   a need to replace Diablo II code with code that is declared under the   *
+ *   configurations scope.                                                   *
+ *                                                                           *
+ *****************************************************************************/
 
 .intel_syntax
 .global _getConfigResolutionInterception@4

--- a/src/D2HD/D2HDDraw.cpp
+++ b/src/D2HD/D2HDDraw.cpp
@@ -1,28 +1,28 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   Defines the functions that corrects standard Diablo II draw functions *
- *   to work with higher resolutions. It also defines new draw calls to    *
- *   imitate the look of D2MultiRes.                                       *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   Defines the functions that corrects standard Diablo II draw functions   *
+ *   to work with higher resolutions. It also defines new draw calls to      *
+ *   imitate the look of D2MultiRes.                                         *
+ *                                                                           *
+ *****************************************************************************/
 
 /*==========================================================
 * D2Ex2

--- a/src/D2HD/D2HDDraw.h
+++ b/src/D2HD/D2HDDraw.h
@@ -1,28 +1,28 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   Declares the functions that corrects standard Diablo II draw          *
- *   functions to work with higher resolutions. It also declares new draw  *
- *   calls to imitate the look of D2MultiRes.                              *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   Declares the functions that corrects standard Diablo II draw            *
+ *   functions to work with higher resolutions. It also declares new draw    *
+ *   calls to imitate the look of D2MultiRes.                                *
+ *                                                                           *
+ *****************************************************************************/
 
 #pragma once
 

--- a/src/D2HD/D2HDDrawInterception.S
+++ b/src/D2HD/D2HDDrawInterception.S
@@ -1,27 +1,27 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   The file defines the interception functions used to call the draw     *
- *   functions safely.                                                     *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   The file defines the interception functions used to call the draw       *
+ *   functions safely.                                                       *
+ *                                                                           *
+ *****************************************************************************/
 
 .intel_syntax
 

--- a/src/D2HD/D2HDInventory.cpp
+++ b/src/D2HD/D2HDInventory.cpp
@@ -1,27 +1,27 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   This file defines the functions that are used to correctly position   *
- *   items in the inventory.                                               *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   This file defines the functions that are used to correctly position     *
+ *   items in the inventory.                                                 *
+ *                                                                           *
+ *****************************************************************************/
 
 /*==========================================================
 * D2Ex2

--- a/src/D2HD/D2HDInventory.h
+++ b/src/D2HD/D2HDInventory.h
@@ -1,27 +1,27 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   The file defines a set of functions that comes from D2Ex2 and are     *
- *   used for correcting the position of items in the inventory.           *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   The file defines a set of functions that comes from D2Ex2 and are       *
+ *   used for correcting the position of items in the inventory.             *
+ *                                                                           *
+ *****************************************************************************/
 
 /*==========================================================
 * D2Ex2

--- a/src/D2HD/D2HDPatches.cpp
+++ b/src/D2HD/D2HDPatches.cpp
@@ -1,30 +1,30 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   Defines functions that are intended to replace instruction code in    *
- *   the Diablo II game process.                                           *
- *                                                                         *
- *   These functions cannot be called without a proper corresponding       *
- *   interception function.                                                *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   Defines functions that are intended to replace instruction code in      *
+ *   the Diablo II game process.                                             *
+ *                                                                           *
+ *   These functions cannot be called without a proper corresponding         *
+ *   interception function.                                                  *
+ *                                                                           *
+ *****************************************************************************/
 
 /*==========================================================
 * D2Ex2

--- a/src/D2HD/D2HDPatches.h
+++ b/src/D2HD/D2HDPatches.h
@@ -1,27 +1,27 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   Declares the functions that expands Diablo II's standard functions to *
- *   allow changing to and using custom resolutions.                       *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   Declares the functions that expands Diablo II's standard functions to   *
+ *   allow changing to and using custom resolutions.                         *
+ *                                                                           *
+ *****************************************************************************/
 
 /*==========================================================
 * D2Ex2

--- a/src/D2HD/D2HDPatchesInterception.S
+++ b/src/D2HD/D2HDPatchesInterception.S
@@ -1,29 +1,29 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   Defines interception functions with low-level x86 code to safely      *
- *   allow modifying Diablo II's internal code.                            *
- *                                                                         *
- *   Used by GCC as a replacement for __declspec(naked).                   *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   Defines interception functions with low-level x86 code to safely        *
+ *   allow modifying Diablo II's internal code.                              *
+ *                                                                           *
+ *   Used by GCC as a replacement for __declspec(naked).                     *
+ *                                                                           *
+ *****************************************************************************/
 
 .intel_syntax
 

--- a/src/D2HD/D2HDResolution.cpp
+++ b/src/D2HD/D2HDResolution.cpp
@@ -1,27 +1,27 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   Defines a class that stores resolutions and the list of resolutions   *
- *   intended for the game.                                                *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   Defines a class that stores resolutions and the list of resolutions     *
+ *   intended for the game.                                                  *
+ *                                                                           *
+ *****************************************************************************/
 
 #include "D2HDResolution.h"
 

--- a/src/D2HD/D2HDResolution.h
+++ b/src/D2HD/D2HDResolution.h
@@ -1,27 +1,27 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   Declares a class that stores resolutions and the list of resolutions  *
- *   intended for the game.                                                *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   Declares a class that stores resolutions and the list of resolutions    *
+ *   intended for the game.                                                  *
+ *                                                                           *
+ *****************************************************************************/
 
 #pragma once
 

--- a/src/D2Patches.h
+++ b/src/D2Patches.h
@@ -1,22 +1,22 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *****************************************************************************/
 
 /*****************************************************************************
  *                                                                           *

--- a/src/D2Ptrs.h
+++ b/src/D2Ptrs.h
@@ -1,22 +1,22 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *****************************************************************************/
 
 /*****************************************************************************
  *                                                                           *

--- a/src/D2Structs.h
+++ b/src/D2Structs.h
@@ -1,22 +1,22 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *****************************************************************************/
 
 /*****************************************************************************
  *                                                                           *

--- a/src/D2Stubs.cpp
+++ b/src/D2Stubs.cpp
@@ -1,27 +1,27 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *    Defines the functions that are used to help call functions in        *
- *    Diablo II that do not conform to standard calling conventions.       *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *    Defines the functions that are used to help call functions in          *
+ *    Diablo II that do not conform to standard calling conventions.         *
+ *                                                                           *
+ *****************************************************************************/
 
 #include "D2Stubs.h"
 

--- a/src/D2Stubs.h
+++ b/src/D2Stubs.h
@@ -1,30 +1,30 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   This file is used to declare stubs that will be used to call game     *
- *   functions that do not conform to STDCALL or FASTCALL conventions.     *
- *                                                                         *
- *   For example, a function that would need a stub function to be called  *
- *   would be one that puts the first parameter into register ESI.         *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   This file is used to declare stubs that will be used to call game       *
+ *   functions that do not conform to STDCALL or FASTCALL conventions.       *
+ *                                                                           *
+ *   For example, a function that would need a stub function to be called    *
+ *   would be one that puts the first parameter into register ESI.           *
+ *                                                                           *
+ *****************************************************************************/
 
 /*==========================================================
 * D2Ex2

--- a/src/D2StubsAsm.S
+++ b/src/D2StubsAsm.S
@@ -1,27 +1,27 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- *-------------------------------------------------------------------------*
- *                                                                         *
- *   Defines the x86 functions that are used to help call functions in     *
- *   Diablo II that do not conform to standard calling conventions.        *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *---------------------------------------------------------------------------*
+ *                                                                           *
+ *   Defines the x86 functions that are used to help call functions in       *
+ *   Diablo II that do not conform to standard calling conventions.          *
+ *                                                                           *
+ *****************************************************************************/
 .intel_syntax
 
 .global _loadMPQStub@28

--- a/src/D2Vars.h
+++ b/src/D2Vars.h
@@ -1,22 +1,22 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *****************************************************************************/
 
 /*****************************************************************************
  *                                                                           *

--- a/src/DLLmain.cpp
+++ b/src/DLLmain.cpp
@@ -1,22 +1,22 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *****************************************************************************/
 
 /*****************************************************************************
  *                                                                           *

--- a/src/DLLmain.h
+++ b/src/DLLmain.h
@@ -1,22 +1,22 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *****************************************************************************/
 
 /*****************************************************************************
  *                                                                           *

--- a/src/TemplateIncludes.h
+++ b/src/TemplateIncludes.h
@@ -1,22 +1,22 @@
-/***************************************************************************
- *                                                                         *
- *   SlashDiablo HD                                                        *
- *   Copyright (C) 2017  Mir Drualga                                       *
- *                                                                         *
- *   This program is free software: you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation, either version 3 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- *   This program is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU General Public License for more details.                          *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
- *                                                                         *
- ***************************************************************************/
+/*****************************************************************************
+ *                                                                           *
+ *  SlashDiablo HD                                                           *
+ *  Copyright (C) 2017  Mir Drualga                                          *
+ *                                                                           *
+ *  This program is free software: you can redistribute it and/or modify     *
+ *  it under the terms of the GNU Affero General Public License as published *
+ *  by the Free Software Foundation, either version 3 of the License, or     *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  This program is distributed in the hope that it will be useful,          *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU Affero General Public License for more details.                      *
+ *                                                                           *
+ *  You should have received a copy of the GNU Affero General Public License *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                           *
+ *****************************************************************************/
 
 /*****************************************************************************
  *                                                                           *


### PR DESCRIPTION
planqi's BH is licensed AGPL, and a license upgrade is required to work with it. Also, AGPL can be beneficial by preventing people from taking this code and applying it to their D2 server, effectively bypassing the GPL requirement.